### PR TITLE
ci(smoke): test production deployments

### DIFF
--- a/.github/workflows/deployed-smoke.yml
+++ b/.github/workflows/deployed-smoke.yml
@@ -1,0 +1,59 @@
+name: Deployed Smoke
+
+on:
+  deployment_status:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Fully qualified deployed app URL to smoke test.
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Playwright deployed smoke
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.deployment_status.state == 'success' &&
+        github.event.deployment.environment == 'Production'
+      )
+    runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || github.event.deployment_status.environment_url }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Validate smoke target
+        run: |
+          if [ -z "$PLAYWRIGHT_BASE_URL" ]; then
+            echo "PLAYWRIGHT_BASE_URL is required."
+            exit 1
+          fi
+
+          case "$PLAYWRIGHT_BASE_URL" in
+            http://*|https://*) ;;
+            *)
+              echo "PLAYWRIGHT_BASE_URL must be an absolute http(s) URL."
+              exit 1
+              ;;
+          esac
+
+      - name: Run deployed browser smoke tests
+        run: npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A GitHub-themed web application that discovers your origin story on GitHub. Ente
 
 ### Prerequisites
 
-- Node.js 22, or any version matching `>=20.9.0`
+- Node.js 22
 - npm
 
 ### Installation
@@ -75,6 +75,8 @@ Or point the smoke test at any deployed URL:
 PLAYWRIGHT_BASE_URL=https://your-deployment.example npm run test:e2e
 ```
 
+Production deployments also trigger the deployed smoke test automatically through the `Deployed Smoke` GitHub Actions workflow. Manual runs of that workflow require a deployed URL.
+
 For active test-driven development:
 
 ```bash
@@ -87,6 +89,7 @@ npm run test:watch
 - The token is only used server-side by the GitHub API client and is not exposed to the browser.
 - Usernames entered into the search field are sent to GitHub to retrieve public commit data; the app does not store searches.
 - CI runs on every push and pull request to `main`.
+- Production deployment smoke tests run after a successful Vercel deployment and can also be started manually from GitHub Actions.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
Adds an automated deployed smoke test workflow so successful production deployments are checked against the real Vercel environment URL.

## Changes
- Add a Deployed Smoke GitHub Actions workflow triggered by successful production deployment statuses.
- Use the deployment status environment URL for automatic production smoke runs.
- Add a manual workflow_dispatch fallback that requires an explicit deployed URL.
- Document the automatic and manual deployed smoke test behavior in the README.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing steps:
  - ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deployed-smoke.yml'); puts 'workflow yaml ok'"
  - npm run test:e2e:deployed
  - npm test
  - npm run lint
  - npm run build

## Screenshots (if applicable)
N/A

## Related Issues
Closes #