### PR TITLE
fix(smoke): use production alias for deployed tests

### DIFF
--- a/.github/workflows/deployed-smoke.yml
+++ b/.github/workflows/deployed-smoke.yml
@@ -22,7 +22,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     env:
-      PLAYWRIGHT_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || github.event.deployment_status.environment_url }}
+      PLAYWRIGHT_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || vars.PRODUCTION_BASE_URL || github.event.deployment_status.environment_url }}
 
     steps:
       - name: Check out repository
@@ -44,6 +44,7 @@ jobs:
         run: |
           if [ -z "$PLAYWRIGHT_BASE_URL" ]; then
             echo "PLAYWRIGHT_BASE_URL is required."
+            echo "Set PRODUCTION_BASE_URL as a repository variable or provide base_url for manual runs."
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Or point the smoke test at any deployed URL:
 PLAYWRIGHT_BASE_URL=https://your-deployment.example npm run test:e2e
 ```
 
-Production deployments also trigger the deployed smoke test automatically through the `Deployed Smoke` GitHub Actions workflow. Manual runs of that workflow require a deployed URL.
+Production deployments also trigger the deployed smoke test automatically through the `Deployed Smoke` GitHub Actions workflow. Set the `PRODUCTION_BASE_URL` GitHub Actions repository variable to the public production URL. Manual runs of that workflow require a deployed URL.
 
 For active test-driven development:
 
@@ -89,7 +89,7 @@ npm run test:watch
 - The token is only used server-side by the GitHub API client and is not exposed to the browser.
 - Usernames entered into the search field are sent to GitHub to retrieve public commit data; the app does not store searches.
 - CI runs on every push and pull request to `main`.
-- Production deployment smoke tests run after a successful Vercel deployment and can also be started manually from GitHub Actions.
+- Production deployment smoke tests run after a successful Vercel deployment using the `PRODUCTION_BASE_URL` repository variable, and can also be started manually from GitHub Actions.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
Fixes deployed smoke failures caused by Vercel protected deployment URLs returning 401.

## Changes
- Use the PRODUCTION_BASE_URL repository variable for automatic production smoke runs.
- Fall back to the deployment environment URL only if the repository variable is not set.
- Document the required repository variable in the README.
- Set PRODUCTION_BASE_URL to https://my-first-commit-eta.vercel.app in repository variables.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing steps:
  - ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deployed-smoke.yml'); puts 'workflow yaml ok'"
  - curl -L --max-time 20 -s -D - https://my-first-commit-ougqewazd-scottdensmores-projects.vercel.app
  - curl -L --max-time 20 -s -D - https://my-first-commit-eta.vercel.app
  - gh variable list -R scottdensmore/my-first-commit --json name,value --jq '.[] | select(.name == "PRODUCTION_BASE_URL")'
  - npm run test:e2e:deployed
  - npm run lint
  - npm test

## Screenshots (if applicable)
N/A

## Related Issues
Closes #