### PR TITLE
feat(analytics): add Vercel Analytics

### DIFF
--- a/app/layout.test.tsx
+++ b/app/layout.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import RootLayout from "./layout";
+
+vi.mock("next/font/google", () => ({
+  Geist: () => ({ variable: "geist-sans" }),
+  Geist_Mono: () => ({ variable: "geist-mono" }),
+}));
+
+vi.mock("@vercel/analytics/next", () => ({
+  Analytics: () => <div data-testid="vercel-analytics" />,
+}));
+
+describe("RootLayout", () => {
+  it("mounts Vercel Analytics globally", () => {
+    render(
+      <RootLayout>
+        <main>Page content</main>
+      </RootLayout>,
+    );
+
+    expect(screen.getByText("Page content")).toBeInTheDocument();
+    expect(screen.getByTestId("vercel-analytics")).toBeInTheDocument();
+  });
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
@@ -47,6 +48,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Analytics />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "next": "16.2.4",
@@ -3219,6 +3220,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:e2e:deployed": "PLAYWRIGHT_BASE_URL=https://my-first-commit-eta.vercel.app playwright test"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "next": "16.2.4",


### PR DESCRIPTION
## Summary
Adds Vercel Analytics so the deployed app can report basic production usage data.

## Changes
- Add the official @vercel/analytics package.
- Mount the Analytics component in the root app layout.
- Add a layout unit test that verifies analytics is mounted globally.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm audit
  - npm run lint
  - npm test
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #