### PR TITLE
feat(logging): structure GitHub API errors

### DIFF
--- a/app/actions.test.ts
+++ b/app/actions.test.ts
@@ -169,8 +169,8 @@ describe("getCommits", () => {
       error: "GitHub rate limit reached. Please try again in a few minutes.",
       commits: [],
     });
-    expect(console.warn).toHaveBeenCalledWith("github_commit_search_rate_limited", {
-      username: "octo",
+    expect(console.warn).toHaveBeenCalledWith({
+      event: "github_commit_search_rate_limited",
       status: 403,
       message: "API rate limit exceeded for user.",
       rateLimitRemaining: "0",
@@ -189,8 +189,8 @@ describe("getCommits", () => {
       error: "GitHub rate limit reached. Please try again in a few minutes.",
       commits: [],
     });
-    expect(console.warn).toHaveBeenCalledWith("github_commit_search_rate_limited", {
-      username: "octo",
+    expect(console.warn).toHaveBeenCalledWith({
+      event: "github_commit_search_rate_limited",
       status: 429,
       message: "Too many requests",
       rateLimitRemaining: undefined,
@@ -211,8 +211,8 @@ describe("getCommits", () => {
       commits: [],
     });
     expect(console.warn).not.toHaveBeenCalled();
-    expect(console.error).toHaveBeenCalledWith("github_commit_search_failed", {
-      username: "octo",
+    expect(console.error).toHaveBeenCalledWith({
+      event: "github_commit_search_failed",
       status: 403,
       message: "Resource not accessible by integration",
     }, error);
@@ -227,8 +227,8 @@ describe("getCommits", () => {
       error: "Validation failed. User might not exist.",
       commits: [],
     });
-    expect(console.error).toHaveBeenCalledWith("github_commit_search_failed", {
-      username: "octo",
+    expect(console.error).toHaveBeenCalledWith({
+      event: "github_commit_search_failed",
       status: 422,
       message: undefined,
     }, error);
@@ -243,8 +243,8 @@ describe("getCommits", () => {
       error: "Failed to fetch commits.",
       commits: [],
     });
-    expect(console.error).toHaveBeenCalledWith("github_commit_search_failed", {
-      username: "octo",
+    expect(console.error).toHaveBeenCalledWith({
+      event: "github_commit_search_failed",
       status: undefined,
       message: "GitHub is unavailable",
     }, error);

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { Octokit } from "octokit";
+import { logger } from "./logger";
 
 const octokit = new Octokit({
     auth: process.env.GITHUB_TOKEN 
@@ -115,19 +116,23 @@ export async function getCommits(username: string): Promise<CommitData> {
     const { status } = errorDetails;
 
     if (isGitHubRateLimitError(errorDetails)) {
-      console.warn("github_commit_search_rate_limited", {
-        username,
-        status,
-        message: errorDetails.message,
-        rateLimitRemaining: errorDetails.rateLimitRemaining,
-        rateLimitReset: errorDetails.rateLimitReset,
+      logger.warn({
+        event: "github_commit_search_rate_limited",
+        fields: {
+          status: typeof status === "number" ? status : undefined,
+          message: errorDetails.message,
+          rateLimitRemaining: errorDetails.rateLimitRemaining,
+          rateLimitReset: errorDetails.rateLimitReset,
+        },
       });
       errorMessage = "GitHub rate limit reached. Please try again in a few minutes.";
     } else {
-      console.error("github_commit_search_failed", {
-        username,
-        status,
-        message: errorDetails.message,
+      logger.error({
+        event: "github_commit_search_failed",
+        fields: {
+          status: typeof status === "number" ? status : undefined,
+          message: errorDetails.message,
+        },
       }, error);
     }
 

--- a/app/logger.test.ts
+++ b/app/logger.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logger } from "./logger";
+
+describe("logger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the reserved event name when fields contain an event key", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    logger.warn({
+      event: "github_commit_search_rate_limited",
+      fields: {
+        event: "overridden",
+        status: 403,
+      },
+    });
+
+    expect(console.warn).toHaveBeenCalledWith({
+      event: "github_commit_search_rate_limited",
+      status: 403,
+    });
+  });
+});

--- a/app/logger.ts
+++ b/app/logger.ts
@@ -1,0 +1,31 @@
+type LogLevel = "error" | "warn";
+
+export type LogFields = Record<string, string | number | boolean | null | undefined>;
+
+export type LogEvent = {
+  event: string;
+  fields?: LogFields;
+};
+
+function writeLog(level: LogLevel, { event, fields = {} }: LogEvent, error?: unknown) {
+  const payload = {
+    ...fields,
+    event,
+  };
+
+  if (error === undefined) {
+    console[level](payload);
+    return;
+  }
+
+  console[level](payload, error);
+}
+
+export const logger = {
+  warn(logEvent: LogEvent) {
+    writeLog("warn", logEvent);
+  },
+  error(logEvent: LogEvent, error?: unknown) {
+    writeLog("error", logEvent, error);
+  },
+};


### PR DESCRIPTION
## Summary
Adds lightweight structured server-side logging around GitHub API failures and rate limits without logging searched usernames.

## Changes
- Add a small logger helper for structured warning/error payloads.
- Replace ad hoc GitHub API console logging with structured events.
- Preserve rate-limit status, reset, remaining count, and sanitized error message fields.
- Update server action tests to assert sanitized structured logs.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm audit
  - npm run lint
  - npm test
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #