### PR TITLE
ci(smoke): create issue on production smoke failure

### DIFF
--- a/.github/workflows/deployed-smoke.yml
+++ b/.github/workflows/deployed-smoke.yml
@@ -61,7 +61,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Create or update smoke failure issue
-        if: failure()
+        if: failure() && github.event_name == 'deployment_status'
         env:
           GH_TOKEN: ${{ github.token }}
           SMOKE_TARGET: ${{ env.PLAYWRIGHT_BASE_URL }}
@@ -79,7 +79,7 @@ jobs:
           BODY
           )"
 
-          issue_number="$(gh issue list --state open --search "${issue_title} in:title" --json number --jq '.[0].number')"
+          issue_number="$(gh issue list --state open --search "${issue_title} in:title" --json number --jq '.[0].number // empty')"
 
           if [ -n "$issue_number" ]; then
             gh issue comment "$issue_number" --body "$issue_body"

--- a/.github/workflows/deployed-smoke.yml
+++ b/.github/workflows/deployed-smoke.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   smoke:
@@ -58,3 +59,30 @@ jobs:
 
       - name: Run deployed browser smoke tests
         run: npm run test:e2e
+
+      - name: Create or update smoke failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SMOKE_TARGET: ${{ env.PLAYWRIGHT_BASE_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          issue_title="Production smoke test failed"
+          issue_body="$(cat <<BODY
+          The production smoke test failed.
+
+          - Target: ${SMOKE_TARGET}
+          - Workflow run: ${RUN_URL}
+          - Commit: ${GITHUB_SHA}
+
+          Review the workflow logs, confirm the deployed app loads, and update this issue with the resolution.
+          BODY
+          )"
+
+          issue_number="$(gh issue list --state open --search "${issue_title} in:title" --json number --jq '.[0].number')"
+
+          if [ -n "$issue_number" ]; then
+            gh issue comment "$issue_number" --body "$issue_body"
+          else
+            gh issue create --title "$issue_title" --body "$issue_body"
+          fi

--- a/docs/production.md
+++ b/docs/production.md
@@ -36,6 +36,25 @@ PRODUCTION_BASE_URL=https://my-first-commit-eta.vercel.app
 
 The production deploy is healthy when both `CI / validate` and `Deployed Smoke` pass on `main`.
 
+## Production Smoke Alerts
+
+When `Deployed Smoke` fails, GitHub Actions opens or updates a GitHub issue titled:
+
+```text
+Production smoke test failed
+```
+
+Use that issue as the incident record. It includes the smoke target, workflow run, and commit SHA.
+
+When responding to a smoke failure:
+
+1. Open the workflow run linked from the issue.
+2. Confirm the smoke target is the public production URL.
+3. Open production manually and check whether the app renders.
+4. Fix the deployment, configuration, or app regression.
+5. Re-run `Deployed Smoke` or deploy a fix.
+6. Close the issue after production smoke passes again.
+
 ## Manual Validation
 
 Run the core checks locally:


### PR DESCRIPTION
## Summary
Add GitHub issue alerts when production smoke tests fail.

## Changes
- Allow the deployed smoke workflow to write issues while keeping contents read-only.
- Create a new "Production smoke test failed" issue or comment on the existing open one when smoke fails.
- Document the incident response path in the production runbook.

## Testing
- [x] Unit tests added/updated: not applicable; workflow/documentation change only
- [x] Manual testing steps:
  - actionlint .github/workflows/deployed-smoke.yml
  - npm test
  - npm run lint

## Screenshots (if applicable)
N/A

## Related Issues
Closes #