### PR TITLE
docs(production): document Vercel observability

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -83,6 +83,15 @@ You can also start `Deployed Smoke` manually from GitHub Actions. Provide the pu
 
 ## Observability
 
+This app intentionally uses Vercel-only observability. Do not add Sentry, GlitchTip, or another paid error-monitoring service unless the app grows beyond personal use.
+
+Use these signals together:
+
+- Vercel Analytics for traffic and page-level usage.
+- Vercel Logs for runtime errors and server-side GitHub API failures.
+- GitHub Actions for CI and deployed smoke status.
+- GitHub issues for production smoke incidents.
+
 ### Vercel Analytics
 
 Use Vercel Analytics to answer:
@@ -92,6 +101,18 @@ Use Vercel Analytics to answer:
 - Did usage change after a deploy?
 
 If analytics look empty after a production deploy, confirm the app includes `@vercel/analytics` and that the latest production deploy completed.
+
+### Vercel Logs
+
+Use Vercel Logs when the app is slow, returns an error, or search behavior looks wrong.
+
+In Vercel:
+
+1. Open the `my-first-commit` project.
+2. Go to `Logs`.
+3. Filter to the production deployment.
+4. Search for `github_commit_search_rate_limited` or `github_commit_search_failed`.
+5. Check whether failures line up with a recent deploy, missing environment variable, GitHub rate limit, or invalid search input.
 
 ### Structured Logs
 


### PR DESCRIPTION
## Summary
Document the decision to keep observability on Vercel for this personal app.

## Changes
- Add a Vercel-only observability note to the production runbook.
- Document when and how to use Vercel Logs.
- Tie log review to the existing structured GitHub API events.

## Testing
- [x] Unit tests added/updated: not applicable; documentation only
- [x] Manual testing steps:
  - git diff --check
  - rg -n "Vercel-only|Vercel Logs|Sentry|GlitchTip|github_commit_search" docs/production.md

## Screenshots (if applicable)
N/A

## Related Issues
Closes #