### PR TITLE
feat(search): polish loading and empty states

### DIFF
--- a/app/actions.test.ts
+++ b/app/actions.test.ts
@@ -58,6 +58,7 @@ describe("getCommits", () => {
     await expect(getCommits("")).resolves.toEqual({
       found: false,
       error: "Username is required",
+      errorKind: "validation",
       commits: [],
     });
     expect(searchCommits).not.toHaveBeenCalled();
@@ -148,6 +149,7 @@ describe("getCommits", () => {
     await expect(getCommits("octo")).resolves.toEqual({
       found: false,
       error: "No public commits found for this user (or indexing is delayed).",
+      errorKind: "empty",
       commits: [],
     });
   });
@@ -167,6 +169,7 @@ describe("getCommits", () => {
     await expect(getCommits("octo")).resolves.toEqual({
       found: false,
       error: "GitHub rate limit reached. Please try again in a few minutes.",
+      errorKind: "rate_limit",
       commits: [],
     });
     expect(console.warn).toHaveBeenCalledWith({
@@ -187,6 +190,7 @@ describe("getCommits", () => {
     await expect(getCommits("octo")).resolves.toEqual({
       found: false,
       error: "GitHub rate limit reached. Please try again in a few minutes.",
+      errorKind: "rate_limit",
       commits: [],
     });
     expect(console.warn).toHaveBeenCalledWith({
@@ -208,6 +212,7 @@ describe("getCommits", () => {
     await expect(getCommits("octo")).resolves.toEqual({
       found: false,
       error: "Failed to fetch commits.",
+      errorKind: "unknown",
       commits: [],
     });
     expect(console.warn).not.toHaveBeenCalled();
@@ -225,6 +230,7 @@ describe("getCommits", () => {
     await expect(getCommits("octo")).resolves.toEqual({
       found: false,
       error: "Validation failed. User might not exist.",
+      errorKind: "validation",
       commits: [],
     });
     expect(console.error).toHaveBeenCalledWith({
@@ -241,6 +247,7 @@ describe("getCommits", () => {
     await expect(getCommits("octo")).resolves.toEqual({
       found: false,
       error: "Failed to fetch commits.",
+      errorKind: "unknown",
       commits: [],
     });
     expect(console.error).toHaveBeenCalledWith({

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -34,6 +34,7 @@ export interface CommitInfo {
 export interface CommitData {
   found: boolean;
   error?: string;
+  errorKind?: "empty" | "rate_limit" | "validation" | "unknown";
   commits: CommitInfo[];
 }
 
@@ -72,7 +73,7 @@ function isGitHubRateLimitError(errorDetails: GitHubErrorDetails) {
 }
 
 export async function getCommits(username: string): Promise<CommitData> {
-  if (!username) return { found: false, error: "Username is required", commits: [] };
+  if (!username) return { found: false, error: "Username is required", errorKind: "validation", commits: [] };
 
   try {
     const response = await octokit.rest.search.commits({
@@ -85,7 +86,12 @@ export async function getCommits(username: string): Promise<CommitData> {
     const items = response.data.items;
 
     if (!items || items.length === 0) {
-      return { found: false, error: "No public commits found for this user (or indexing is delayed).", commits: [] };
+      return {
+        found: false,
+        error: "No public commits found for this user (or indexing is delayed).",
+        errorKind: "empty",
+        commits: [],
+      };
     }
 
     const commits = items.map(item => ({
@@ -126,6 +132,7 @@ export async function getCommits(username: string): Promise<CommitData> {
         },
       });
       errorMessage = "GitHub rate limit reached. Please try again in a few minutes.";
+      return { found: false, error: errorMessage, errorKind: "rate_limit", commits: [] };
     } else {
       logger.error({
         event: "github_commit_search_failed",
@@ -136,8 +143,11 @@ export async function getCommits(username: string): Promise<CommitData> {
       }, error);
     }
 
-    if (status === 422) errorMessage = "Validation failed. User might not exist.";
+    if (status === 422) {
+      errorMessage = "Validation failed. User might not exist.";
+      return { found: false, error: errorMessage, errorKind: "validation", commits: [] };
+    }
     
-    return { found: false, error: errorMessage, commits: [] };
+    return { found: false, error: errorMessage, errorKind: "unknown", commits: [] };
   }
 }

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -88,6 +88,7 @@ describe("Home", () => {
     mockGetCommits.mockResolvedValue({
       found: false,
       error: "No public commits found for this user (or indexing is delayed).",
+      errorKind: "empty",
       commits: [],
     });
     const user = userEvent.setup();
@@ -97,6 +98,7 @@ describe("Home", () => {
     await user.click(screen.getByRole("button", { name: /^search$/i }));
 
     expect(await screen.findByRole("heading", { name: /no public commits found/i })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/no public commits found/i);
     expect(screen.getByText(/try another username or check back later/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /edit username/i })).toBeInTheDocument();
   });
@@ -105,6 +107,7 @@ describe("Home", () => {
     mockGetCommits.mockResolvedValue({
       found: false,
       error: "GitHub rate limit reached. Please try again in a few minutes.",
+      errorKind: "rate_limit",
       commits: [],
     });
     const user = userEvent.setup();
@@ -114,8 +117,31 @@ describe("Home", () => {
     await user.click(screen.getByRole("button", { name: /^search$/i }));
 
     expect(await screen.findByRole("heading", { name: /github is asking us to slow down/i })).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/github is asking us to slow down/i);
     expect(screen.getByText(/wait a few minutes/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("retries the username that produced a rate-limit error", async () => {
+    mockGetCommits.mockResolvedValue({
+      found: false,
+      error: "GitHub rate limit reached. Please try again in a few minutes.",
+      errorKind: "rate_limit",
+      commits: [],
+    });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    const input = screen.getByRole("searchbox", { name: /github username/i });
+    await user.type(input, "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    await screen.findByRole("heading", { name: /github is asking us to slow down/i });
+
+    await user.clear(input);
+    await user.type(input, "someone-else");
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(mockGetCommits).toHaveBeenLastCalledWith("octo");
   });
 
   it("clears the result and refocuses the search field when searching again", async () => {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -65,6 +65,59 @@ describe("Home", () => {
     expect(await screen.findByRole("link", { name: "Initial commit" })).toBeInTheDocument();
   });
 
+  it("announces the search while a request is pending", async () => {
+    let resolveSearch: (value: typeof commitResult) => void = () => undefined;
+    mockGetCommits.mockReturnValue(new Promise((resolve) => {
+      resolveSearch = resolve;
+    }));
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(screen.getByRole("status")).toHaveTextContent(/searching github for octo/i);
+    expect(screen.getByRole("button", { name: /searching/i })).toBeDisabled();
+
+    resolveSearch(commitResult);
+
+    expect(await screen.findByRole("link", { name: "Initial commit" })).toBeInTheDocument();
+  });
+
+  it("renders a helpful empty state when no public commits are found", async () => {
+    mockGetCommits.mockResolvedValue({
+      found: false,
+      error: "No public commits found for this user (or indexing is delayed).",
+      commits: [],
+    });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "new-user");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(await screen.findByRole("heading", { name: /no public commits found/i })).toBeInTheDocument();
+    expect(screen.getByText(/try another username or check back later/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit username/i })).toBeInTheDocument();
+  });
+
+  it("renders a recovery-focused error state for rate limits", async () => {
+    mockGetCommits.mockResolvedValue({
+      found: false,
+      error: "GitHub rate limit reached. Please try again in a few minutes.",
+      commits: [],
+    });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(await screen.findByRole("heading", { name: /github is asking us to slow down/i })).toBeInTheDocument();
+    expect(screen.getByText(/wait a few minutes/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
   it("clears the result and refocuses the search field when searching again", async () => {
     mockGetCommits.mockResolvedValue(commitResult);
     const user = userEvent.setup();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,8 +40,9 @@ export default function Home() {
   };
 
   const errorMessage = result && !result.found ? result.error ?? "User not found or no public commits." : "";
-  const isRateLimited = /rate limit/i.test(errorMessage);
-  const isEmptyResult = /No public commits found/i.test(errorMessage);
+  const isRateLimited = result?.errorKind === "rate_limit";
+  const isEmptyResult = result?.errorKind === "empty";
+  const resultStateRole = isEmptyResult ? "status" : "alert";
 
   return (
     <div className="min-h-screen flex flex-col bg-[var(--background)] font-sans">
@@ -119,7 +120,7 @@ export default function Home() {
 
         {/* Empty and Error States */}
         {result && !result.found && (
-            <div role="alert" className={`mt-8 w-full max-w-md rounded-md border p-5 text-left shadow-sm ${isEmptyResult ? 'border-[var(--github-border)] bg-[var(--github-gray-light)] text-[var(--github-gray-dark)]' : 'border-red-200 bg-red-50 text-red-800'}`}>
+            <div role={resultStateRole} aria-live={isEmptyResult ? "polite" : undefined} className={`mt-8 w-full max-w-md rounded-md border p-5 text-left shadow-sm ${isEmptyResult ? 'border-[var(--github-border)] bg-[var(--github-gray-light)] text-[var(--github-gray-dark)]' : 'border-red-200 bg-red-50 text-red-800'}`}>
                 <h2 className="text-base font-semibold text-[var(--github-gray-dark)]">
                     {isRateLimited ? "GitHub is asking us to slow down." : isEmptyResult ? "No public commits found." : "We could not complete that search."}
                 </h2>
@@ -134,8 +135,8 @@ export default function Home() {
                     {isRateLimited && (
                         <button
                             type="button"
-                            onClick={() => searchCommits(username)}
-                            disabled={isPending}
+                            onClick={() => searchCommits(lastSearchedUsername)}
+                            disabled={isPending || !lastSearchedUsername}
                             className="inline-flex items-center justify-center rounded-md bg-[var(--github-green)] px-3 py-2 text-sm font-semibold text-white hover:bg-[var(--github-green-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--github-green)] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                         >
                             Try again

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { FaGithub } from "react-icons/fa";
 export default function Home() {
   const [username, setUsername] = useState('');
   const [result, setResult] = useState<CommitData | null>(null);
+  const [lastSearchedUsername, setLastSearchedUsername] = useState('');
   const [isPending, startTransition] = useTransition();
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -17,15 +18,30 @@ export default function Home() {
     }
   }, [result?.found]);
 
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!username.trim()) return;
+  const searchCommits = (searchUsername: string) => {
+    const trimmedUsername = searchUsername.trim();
+    if (!trimmedUsername) return;
 
+    setLastSearchedUsername(trimmedUsername);
     startTransition(async () => {
-       const data = await getCommits(username.trim());
+       const data = await getCommits(trimmedUsername);
        setResult(data);
     });
   };
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    searchCommits(username);
+  };
+
+  const resetSearch = () => {
+    setResult(null);
+    requestAnimationFrame(() => searchInputRef.current?.focus());
+  };
+
+  const errorMessage = result && !result.found ? result.error ?? "User not found or no public commits." : "";
+  const isRateLimited = /rate limit/i.test(errorMessage);
+  const isEmptyResult = /No public commits found/i.test(errorMessage);
 
   return (
     <div className="min-h-screen flex flex-col bg-[var(--background)] font-sans">
@@ -37,7 +53,7 @@ export default function Home() {
          </div>
          {result?.found && (
             <button 
-                onClick={() => { setResult(null); setUsername(''); }}
+                onClick={() => { setResult(null); setUsername(''); setLastSearchedUsername(''); }}
                 className="px-3 py-1.5 text-xs font-semibold text-[var(--github-gray-dark)] bg-white border border-[var(--github-border)] rounded-md hover:bg-gray-50 transition-colors shadow-sm"
             >
                 Search another user
@@ -95,12 +111,43 @@ export default function Home() {
         </form>
         )}
 
-        {/* Error State */}
+        {isPending && (
+            <div role="status" aria-live="polite" className="mt-5 w-full max-w-md rounded-md border border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-3 text-sm text-[var(--github-gray-text)]">
+                Searching GitHub for {lastSearchedUsername}...
+            </div>
+        )}
+
+        {/* Empty and Error States */}
         {result && !result.found && (
-            <div className="mt-8 p-4 rounded-md bg-red-50 border border-red-200 text-red-700 w-full max-w-md text-center animate-pulse">
-                {result.error || "User not found or no public commits."}
-                <div className="mt-2 text-sm">
-                    <button onClick={() => setResult(null)} className="underline hover:no-underline">Try again</button>
+            <div role="alert" className={`mt-8 w-full max-w-md rounded-md border p-5 text-left shadow-sm ${isEmptyResult ? 'border-[var(--github-border)] bg-[var(--github-gray-light)] text-[var(--github-gray-dark)]' : 'border-red-200 bg-red-50 text-red-800'}`}>
+                <h2 className="text-base font-semibold text-[var(--github-gray-dark)]">
+                    {isRateLimited ? "GitHub is asking us to slow down." : isEmptyResult ? "No public commits found." : "We could not complete that search."}
+                </h2>
+                <p className="mt-2 text-sm text-[var(--github-gray-text)]">
+                    {isRateLimited
+                        ? "Wait a few minutes, then try again. GitHub temporarily limited commit search requests."
+                        : isEmptyResult
+                            ? "Try another username or check back later; GitHub commit search indexing can lag."
+                            : errorMessage}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                    {isRateLimited && (
+                        <button
+                            type="button"
+                            onClick={() => searchCommits(username)}
+                            disabled={isPending}
+                            className="inline-flex items-center justify-center rounded-md bg-[var(--github-green)] px-3 py-2 text-sm font-semibold text-white hover:bg-[var(--github-green-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--github-green)] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            Try again
+                        </button>
+                    )}
+                    <button
+                        type="button"
+                        onClick={resetSearch}
+                        className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-2 text-sm font-semibold text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+                    >
+                        Edit username
+                    </button>
                 </div>
             </div>
         )}


### PR DESCRIPTION
## Summary
Polish the search experience with clearer loading, empty, and error states.

## Changes
- Announce pending GitHub searches with an accessible live status.
- Split no-commit results into a neutral empty state with guidance.
- Split rate limits into a recovery-focused error state with retry.
- Keep an edit-username path for all failed searches.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm test -- app/page.test.tsx
  - npm test
  - npm run lint
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #