### PR TITLE
feat(search): validate GitHub usernames

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -65,6 +65,43 @@ describe("Home", () => {
     expect(await screen.findByRole("link", { name: "Initial commit" })).toBeInTheDocument();
   });
 
+  it("shows a username format hint before the user types", () => {
+    render(<Home />);
+
+    expect(screen.getByText(/github usernames can use letters, numbers, or single hyphens/i)).toBeInTheDocument();
+  });
+
+  it("blocks searches for usernames with invalid characters", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo_cat");
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/only letters, numbers, and hyphens/i);
+    expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled();
+    expect(mockGetCommits).not.toHaveBeenCalled();
+  });
+
+  it("blocks searches for usernames with leading or trailing hyphens", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "-octo");
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/cannot start or end with a hyphen/i);
+    expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled();
+  });
+
+  it("blocks searches for usernames longer than GitHub allows", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "a".repeat(40));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/39 characters or fewer/i);
+    expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled();
+  });
+
   it("announces the search while a request is pending", async () => {
     let resolveSearch: (value: typeof commitResult) => void = () => undefined;
     mockGetCommits.mockReturnValue(new Promise((resolve) => {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -77,8 +77,17 @@ describe("Home", () => {
 
     await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo_cat");
 
-    expect(screen.getByRole("alert")).toHaveTextContent(/only letters, numbers, and hyphens/i);
+    expect(screen.getByRole("status")).toHaveTextContent(/only letters, numbers, and hyphens/i);
     expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled();
+    expect(mockGetCommits).not.toHaveBeenCalled();
+  });
+
+  it("does not submit invalid usernames from the keyboard", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo_cat{Enter}");
+
     expect(mockGetCommits).not.toHaveBeenCalled();
   });
 
@@ -88,7 +97,7 @@ describe("Home", () => {
 
     await user.type(screen.getByRole("searchbox", { name: /github username/i }), "-octo");
 
-    expect(screen.getByRole("alert")).toHaveTextContent(/cannot start or end with a hyphen/i);
+    expect(screen.getByRole("status")).toHaveTextContent(/cannot start or end with a hyphen/i);
     expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled();
   });
 
@@ -98,7 +107,17 @@ describe("Home", () => {
 
     await user.type(screen.getByRole("searchbox", { name: /github username/i }), "a".repeat(40));
 
-    expect(screen.getByRole("alert")).toHaveTextContent(/39 characters or fewer/i);
+    expect(screen.getByRole("status")).toHaveTextContent(/39 characters or fewer/i);
+    expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled();
+  });
+
+  it("blocks searches for usernames with consecutive hyphens", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo--cat");
+
+    expect(screen.getByRole("status")).toHaveTextContent(/cannot include consecutive hyphens/i);
     expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled();
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,18 @@ import { getCommits, CommitData } from './actions';
 import FirstCommitDisplay from '@/components/FirstCommitDisplay';
 import { FaGithub } from "react-icons/fa";
 
+function getUsernameValidationMessage(value: string) {
+  const username = value.trim();
+
+  if (!username) return "";
+  if (username.length > 39) return "GitHub usernames must be 39 characters or fewer.";
+  if (!/^[a-zA-Z0-9-]+$/.test(username)) return "Use only letters, numbers, and hyphens.";
+  if (username.startsWith("-") || username.endsWith("-")) return "GitHub usernames cannot start or end with a hyphen.";
+  if (username.includes("--")) return "GitHub usernames cannot include consecutive hyphens.";
+
+  return "";
+}
+
 export default function Home() {
   const [username, setUsername] = useState('');
   const [result, setResult] = useState<CommitData | null>(null);
@@ -43,6 +55,8 @@ export default function Home() {
   const isRateLimited = result?.errorKind === "rate_limit";
   const isEmptyResult = result?.errorKind === "empty";
   const resultStateRole = isEmptyResult ? "status" : "alert";
+  const usernameValidationMessage = getUsernameValidationMessage(username);
+  const canSearch = Boolean(username.trim()) && !usernameValidationMessage && !isPending;
 
   return (
     <div className="min-h-screen flex flex-col bg-[var(--background)] font-sans">
@@ -94,17 +108,29 @@ export default function Home() {
                     value={username}
                     onInput={(e) => setUsername(e.currentTarget.value)}
                     placeholder="username"
+                    aria-describedby="username-hint username-validation"
+                    aria-invalid={Boolean(usernameValidationMessage)}
                     autoComplete="off"
                     autoCorrect="off"
                     autoCapitalize="none"
                     spellCheck={false}
-                    className="block w-full pl-7 pr-3 py-3 border border-[var(--github-border)] rounded-md leading-5 bg-white text-[var(--github-gray-dark)] placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:border-transparent sm:text-sm shadow-sm"
+                    className={`block w-full pl-7 pr-3 py-3 border rounded-md leading-5 bg-white text-[var(--github-gray-dark)] placeholder-gray-400 focus:outline-none focus:ring-2 focus:border-transparent sm:text-sm shadow-sm ${usernameValidationMessage ? 'border-red-300 focus:ring-red-500' : 'border-[var(--github-border)] focus:ring-[var(--github-blue)]'}`}
                     autoFocus
                 />
+                <p id="username-hint" className="mt-2 text-xs text-[var(--github-gray-text)]">
+                    GitHub usernames can use letters, numbers, or single hyphens.
+                </p>
+                <div id="username-validation" aria-live="polite">
+                    {usernameValidationMessage && (
+                        <p role="alert" className="mt-2 text-xs font-medium text-red-700">
+                            {usernameValidationMessage}
+                        </p>
+                    )}
+                </div>
             </div>
             <button
                 type="submit"
-                disabled={isPending || !username.trim()}
+                disabled={!canSearch}
                 className="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-[var(--github-green)] hover:bg-[var(--github-green-hover)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--github-green)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"
             >
                 {isPending ? 'Searching...' : 'Search'}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,7 @@ export default function Home() {
   const searchCommits = (searchUsername: string) => {
     const trimmedUsername = searchUsername.trim();
     if (!trimmedUsername) return;
+    if (getUsernameValidationMessage(trimmedUsername)) return;
 
     setLastSearchedUsername(trimmedUsername);
     startTransition(async () => {
@@ -120,13 +121,11 @@ export default function Home() {
                 <p id="username-hint" className="mt-2 text-xs text-[var(--github-gray-text)]">
                     GitHub usernames can use letters, numbers, or single hyphens.
                 </p>
-                <div id="username-validation" aria-live="polite">
-                    {usernameValidationMessage && (
-                        <p role="alert" className="mt-2 text-xs font-medium text-red-700">
-                            {usernameValidationMessage}
-                        </p>
-                    )}
-                </div>
+                {usernameValidationMessage && (
+                    <p id="username-validation" role="status" aria-live="polite" className="mt-2 text-xs font-medium text-red-700">
+                        {usernameValidationMessage}
+                    </p>
+                )}
             </div>
             <button
                 type="submit"
@@ -138,7 +137,7 @@ export default function Home() {
         </form>
         )}
 
-        {isPending && (
+        {isPending && !result && (
             <div role="status" aria-live="polite" className="mt-5 w-full max-w-md rounded-md border border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-3 text-sm text-[var(--github-gray-text)]">
                 Searching GitHub for {lastSearchedUsername}...
             </div>


### PR DESCRIPTION
## Summary
Add client-side GitHub username validation hints before search requests are sent.

## Changes
- Add a visible username format hint.
- Validate GitHub username length, characters, hyphen placement, and consecutive hyphens.
- Disable search while the username is invalid.
- Wire validation feedback to the input with aria-describedby and aria-invalid.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm test -- app/page.test.tsx
  - npm test
  - npm run lint
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #