### PR TITLE
feat(search): add shareable user URLs

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -35,6 +35,7 @@ const commitResult = {
 describe("Home", () => {
   beforeEach(() => {
     mockGetCommits.mockReset();
+    window.history.replaceState(null, "", "/");
   });
 
   it("focuses the GitHub search field and marks it as a non-credential search box", () => {
@@ -62,7 +63,42 @@ describe("Home", () => {
     await waitFor(() => {
       expect(mockGetCommits).toHaveBeenCalledWith("octo");
     });
+    expect(window.location.search).toBe("?user=octo");
     expect(await screen.findByRole("link", { name: "Initial commit" })).toBeInTheDocument();
+  });
+
+  it("auto-searches a valid username from the URL", async () => {
+    mockGetCommits.mockResolvedValue(commitResult);
+    window.history.replaceState(null, "", "/?user=octo");
+
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(mockGetCommits).toHaveBeenCalledWith("octo");
+    });
+    expect(await screen.findByRole("link", { name: "Initial commit" })).toBeInTheDocument();
+  });
+
+  it("does not auto-search an invalid username from the URL", () => {
+    window.history.replaceState(null, "", "/?user=octo_cat");
+
+    render(<Home />);
+
+    expect(mockGetCommits).not.toHaveBeenCalled();
+    expect(screen.getByRole("searchbox", { name: /github username/i })).toHaveValue("octo_cat");
+    expect(screen.getByRole("status")).toHaveTextContent(/only letters, numbers, and hyphens/i);
+  });
+
+  it("clears the shared URL when searching another user", async () => {
+    mockGetCommits.mockResolvedValue(commitResult);
+    window.history.replaceState(null, "", "/?user=octo");
+    render(<Home />);
+    await screen.findByRole("button", { name: /search another user/i });
+
+    await userEvent.click(screen.getByRole("button", { name: /search another user/i }));
+
+    expect(window.location.search).toBe("");
+    expect(screen.getByRole("searchbox", { name: /github username/i })).toHaveValue("");
   });
 
   it("shows a username format hint before the user types", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useRef, useState, useTransition } from 'react';
+import React, { useCallback, useEffect, useRef, useState, useTransition } from 'react';
 import { getCommits, CommitData } from './actions';
 import FirstCommitDisplay from '@/components/FirstCommitDisplay';
 import { FaGithub } from "react-icons/fa";
@@ -49,7 +49,7 @@ export default function Home() {
     }
   }, [result?.found]);
 
-  const searchCommits = (searchUsername: string, options: { updateUrl?: boolean } = {}) => {
+  const searchCommits = useCallback((searchUsername: string, options: { updateUrl?: boolean } = {}) => {
     const trimmedUsername = searchUsername.trim();
     if (!trimmedUsername) return;
     if (getUsernameValidationMessage(trimmedUsername)) return;
@@ -60,7 +60,7 @@ export default function Home() {
        const data = await getCommits(trimmedUsername);
        setResult(data);
     });
-  };
+  }, []);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -82,7 +82,7 @@ export default function Home() {
     }, 0);
 
     return () => window.clearTimeout(autoSearch);
-  }, []);
+  }, [searchCommits]);
 
   const errorMessage = result && !result.found ? result.error ?? "User not found or no public commits." : "";
   const isRateLimited = result?.errorKind === "rate_limit";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,8 +17,27 @@ function getUsernameValidationMessage(value: string) {
   return "";
 }
 
+function updateSharedSearchUrl(username: string) {
+  const url = new URL(window.location.href);
+  url.searchParams.set("user", username);
+  window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+}
+
+function clearSharedSearchUrl() {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("user");
+  const search = url.searchParams.toString();
+  window.history.replaceState(null, "", `${url.pathname}${search ? `?${search}` : ""}${url.hash}`);
+}
+
+function getInitialSharedUsername() {
+  if (typeof window === "undefined") return "";
+
+  return new URLSearchParams(window.location.search).get("user") ?? "";
+}
+
 export default function Home() {
-  const [username, setUsername] = useState('');
+  const [username, setUsername] = useState(getInitialSharedUsername);
   const [result, setResult] = useState<CommitData | null>(null);
   const [lastSearchedUsername, setLastSearchedUsername] = useState('');
   const [isPending, startTransition] = useTransition();
@@ -30,10 +49,11 @@ export default function Home() {
     }
   }, [result?.found]);
 
-  const searchCommits = (searchUsername: string) => {
+  const searchCommits = (searchUsername: string, options: { updateUrl?: boolean } = {}) => {
     const trimmedUsername = searchUsername.trim();
     if (!trimmedUsername) return;
     if (getUsernameValidationMessage(trimmedUsername)) return;
+    if (options.updateUrl) updateSharedSearchUrl(trimmedUsername);
 
     setLastSearchedUsername(trimmedUsername);
     startTransition(async () => {
@@ -44,13 +64,25 @@ export default function Home() {
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    searchCommits(username);
+    searchCommits(username, { updateUrl: true });
   };
 
   const resetSearch = () => {
     setResult(null);
+    clearSharedSearchUrl();
     requestAnimationFrame(() => searchInputRef.current?.focus());
   };
+
+  useEffect(() => {
+    const sharedUsername = new URLSearchParams(window.location.search).get("user");
+    if (!sharedUsername) return;
+
+    const autoSearch = window.setTimeout(() => {
+      searchCommits(sharedUsername);
+    }, 0);
+
+    return () => window.clearTimeout(autoSearch);
+  }, []);
 
   const errorMessage = result && !result.found ? result.error ?? "User not found or no public commits." : "";
   const isRateLimited = result?.errorKind === "rate_limit";
@@ -69,7 +101,7 @@ export default function Home() {
          </div>
          {result?.found && (
             <button 
-                onClick={() => { setResult(null); setUsername(''); setLastSearchedUsername(''); }}
+                onClick={() => { setResult(null); setUsername(''); setLastSearchedUsername(''); clearSharedSearchUrl(); }}
                 className="px-3 py-1.5 text-xs font-semibold text-[var(--github-gray-dark)] bg-white border border-[var(--github-border)] rounded-md hover:bg-gray-50 transition-colors shadow-sm"
             >
                 Search another user


### PR DESCRIPTION
## Summary
Add shareable search URLs using the existing user query string.

## Changes
- Read a valid ?user=username value on page load and auto-run the search.
- Populate the search field from invalid shared URLs without sending a request.
- Update the URL when a user searches manually.
- Clear the user query parameter when searching another user or editing after an error.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm test -- app/page.test.tsx
  - npm test
  - npm run lint
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #