### PR TITLE
feat(metadata): polish social previews

### DIFF
--- a/app/layout.test.tsx
+++ b/app/layout.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import RootLayout from "./layout";
+import RootLayout, { metadata } from "./layout";
 
 vi.mock("next/font/google", () => ({
   Geist: () => ({ variable: "geist-sans" }),
@@ -12,6 +12,48 @@ vi.mock("@vercel/analytics/next", () => ({
 }));
 
 describe("RootLayout", () => {
+  it("defines production-ready metadata for shared links", () => {
+    expect(metadata.metadataBase?.toString()).toBe("http://localhost:3000/");
+    expect(metadata.title).toEqual({
+      default: "My First Commit",
+      template: "%s | My First Commit",
+    });
+    expect(metadata.description).toBe("Find and share the first public GitHub commit for any user.");
+    expect(metadata.alternates).toEqual({
+      canonical: "/",
+    });
+    expect(metadata.openGraph).toMatchObject({
+      title: "My First Commit",
+      description: "Find and share the first public GitHub commit for any user.",
+      type: "website",
+      url: "/",
+      siteName: "My First Commit",
+      images: [
+        {
+          url: "/opengraph-image",
+          width: 1200,
+          height: 630,
+          alt: "My First Commit social preview",
+        },
+      ],
+    });
+    expect(metadata.twitter).toMatchObject({
+      card: "summary_large_image",
+      title: "My First Commit",
+      description: "Find and share the first public GitHub commit for any user.",
+      images: [
+        {
+          url: "/twitter-image",
+          alt: "My First Commit social preview",
+        },
+      ],
+    });
+    expect(metadata.robots).toEqual({
+      index: true,
+      follow: true,
+    });
+  });
+
   it("mounts Vercel Analytics globally", () => {
     render(
       <RootLayout>

--- a/app/layout.test.tsx
+++ b/app/layout.test.tsx
@@ -13,7 +13,9 @@ vi.mock("@vercel/analytics/next", () => ({
 
 describe("RootLayout", () => {
   it("defines production-ready metadata for shared links", () => {
-    expect(metadata.metadataBase?.toString()).toBe("http://localhost:3000/");
+    const expectedMetadataBase = new URL(process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000").toString();
+
+    expect(metadata.metadataBase?.toString()).toBe(expectedMetadataBase);
     expect(metadata.title).toEqual({
       default: "My First Commit",
       template: "%s | My First Commit",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+const siteDescription = "Find and share the first public GitHub commit for any user.";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -21,19 +22,40 @@ export const metadata: Metadata = {
     default: "My First Commit",
     template: "%s | My First Commit",
   },
-  description: "Find the first public GitHub commit for any user.",
+  description: siteDescription,
   applicationName: "My First Commit",
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
     title: "My First Commit",
-    description: "Find the first public GitHub commit for any user.",
+    description: siteDescription,
     type: "website",
     url: "/",
     siteName: "My First Commit",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "My First Commit social preview",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "My First Commit",
-    description: "Find the first public GitHub commit for any user.",
+    description: siteDescription,
+    images: [
+      {
+        url: "/twitter-image",
+        alt: "My First Commit social preview",
+      },
+    ],
+  },
+  robots: {
+    index: true,
+    follow: true,
   },
 };
 

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-export const alt = "My First Commit";
+export const alt = "My First Commit social preview";
 export const size = {
   width: 1200,
   height: 630,
@@ -68,7 +68,7 @@ export default function OpenGraphImage() {
                 maxWidth: 860,
               }}
             >
-              Find the first public GitHub commit for any user.
+              Find and share the first public GitHub commit for any user.
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
Polish app metadata and social previews now that search URLs are shareable.

## Changes
- Strengthen the shared-link description copy.
- Add canonical, robots, Open Graph image, and Twitter image metadata.
- Align generated social preview alt text and image copy.
- Add metadata coverage in layout tests.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm test -- app/layout.test.tsx
  - npm test
  - npm run lint
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #