### PR TITLE
test(a11y): cover search accessibility flow

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -107,6 +107,28 @@ describe("Home", () => {
     expect(screen.getByText(/github usernames can use letters, numbers, or single hyphens/i)).toBeInTheDocument();
   });
 
+  it("describes the search field with only rendered accessibility text", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    const input = screen.getByRole("searchbox", { name: /github username/i });
+
+    expect(input).toHaveAttribute("aria-describedby", "username-hint");
+    expect(input).not.toHaveAttribute("aria-invalid", "true");
+
+    await user.type(input, "octo_cat");
+
+    expect(input).toHaveAttribute("aria-describedby", "username-hint username-validation");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("status")).toHaveAttribute("id", "username-validation");
+
+    await user.clear(input);
+
+    expect(input).toHaveAttribute("aria-describedby", "username-hint");
+    expect(input).not.toHaveAttribute("aria-invalid", "true");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
   it("blocks searches for usernames with invalid characters", async () => {
     const user = userEvent.setup();
     render(<Home />);
@@ -174,6 +196,27 @@ describe("Home", () => {
     resolveSearch(commitResult);
 
     expect(await screen.findByRole("link", { name: "Initial commit" })).toBeInTheDocument();
+  });
+
+  it("marks the search form as busy while a request is pending", async () => {
+    let resolveSearch: (value: typeof commitResult) => void = () => undefined;
+    mockGetCommits.mockReturnValue(new Promise((resolve) => {
+      resolveSearch = resolve;
+    }));
+    const user = userEvent.setup();
+    render(<Home />);
+
+    const form = screen.getByRole("search", { name: /github commit search/i });
+    expect(form).toHaveAttribute("aria-busy", "false");
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(form).toHaveAttribute("aria-busy", "true");
+
+    resolveSearch(commitResult);
+
+    await screen.findByRole("link", { name: "Initial commit" });
   });
 
   it("renders a helpful empty state when no public commits are found", async () => {
@@ -250,6 +293,27 @@ describe("Home", () => {
     const input = screen.getByRole("searchbox", { name: /github username/i });
     expect(input).toHaveFocus();
     expect(input).toHaveValue("");
+  });
+
+  it("refocuses the search field when editing after an empty result", async () => {
+    mockGetCommits.mockResolvedValue({
+      found: false,
+      error: "No public commits found for this user (or indexing is delayed).",
+      errorKind: "empty",
+      commits: [],
+    });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    const input = screen.getByRole("searchbox", { name: /github username/i });
+    await user.type(input, "new-user");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    await screen.findByRole("heading", { name: /no public commits found/i });
+
+    await user.click(screen.getByRole("button", { name: /edit username/i }));
+
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue("new-user");
   });
 
   it("uses the spaced app name in the header and omits clone branding from the footer", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -89,6 +89,9 @@ export default function Home() {
   const isEmptyResult = result?.errorKind === "empty";
   const resultStateRole = isEmptyResult ? "status" : "alert";
   const usernameValidationMessage = getUsernameValidationMessage(username);
+  const usernameDescriptionIds = usernameValidationMessage
+    ? "username-hint username-validation"
+    : "username-hint";
   const canSearch = Boolean(username.trim()) && !usernameValidationMessage && !isPending;
 
   return (
@@ -125,7 +128,13 @@ export default function Home() {
 
         {/* Search Form */}
         {!result?.found && (
-        <form onSubmit={handleSearch} className="w-full max-w-md flex flex-col sm:flex-row gap-2">
+        <form
+            onSubmit={handleSearch}
+            role="search"
+            aria-label="GitHub commit search"
+            aria-busy={isPending}
+            className="w-full max-w-md flex flex-col sm:flex-row gap-2"
+        >
             <div className="relative flex-1">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-[var(--github-gray-text)]">
                     <span className="font-mono text-sm">@</span>
@@ -141,7 +150,7 @@ export default function Home() {
                     value={username}
                     onInput={(e) => setUsername(e.currentTarget.value)}
                     placeholder="username"
-                    aria-describedby="username-hint username-validation"
+                    aria-describedby={usernameDescriptionIds}
                     aria-invalid={Boolean(usernameValidationMessage)}
                     autoComplete="off"
                     autoCorrect="off"

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -29,6 +29,24 @@ test("home page search field is keyboard-ready and not treated as a credential f
   await expect(page.getByText(/Not affiliated with GitHub/)).toBeVisible();
 });
 
+test("home page blocks invalid usernames without leaving keyboard flow", async ({ page }) => {
+  await page.goto("/");
+
+  const searchBox = page.getByRole("searchbox", { name: "GitHub username" });
+  const searchButton = page.getByRole("button", { name: "Search" });
+
+  await searchBox.fill("octo_cat");
+
+  await expect(searchBox).toHaveAttribute("aria-invalid", "true");
+  await expect(searchBox).toHaveAttribute("aria-describedby", "username-hint username-validation");
+  await expect(page.getByRole("status")).toContainText("Use only letters, numbers, and hyphens.");
+  await expect(searchButton).toBeDisabled();
+
+  await searchBox.press("Enter");
+  await expect(page).not.toHaveURL(/\?user=/);
+  await expect(searchBox).toBeFocused();
+});
+
 test("home page advertises branded app and social preview images", async ({ page, request }) => {
   await page.goto("/");
 


### PR DESCRIPTION
## Summary
Improve the search form accessibility contract and add focused coverage for keyboard, ARIA, and pending-state behavior.

## Changes
- Describe the username input only with rendered helper text IDs.
- Add a named search landmark for the GitHub commit search form.
- Mark the search form busy while a request is pending.
- Add unit coverage for ARIA descriptions, busy state, and refocusing after empty results.
- Add Playwright coverage for invalid username keyboard flow.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm test
  - npm run lint
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #