### PR TITLE
feat(app): add production polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Report something broken in My First Commit.
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+      placeholder: Searching for a valid username shows an unexpected error.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the smallest set of steps that reproduces the issue.
+      placeholder: |
+        1. Open the app
+        2. Search for octocat
+        3. See the error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Extra context
+      description: Add browser, device, URL, screenshots, or logs if useful.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest a small product improvement.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user need or friction does this solve?
+      placeholder: I want to compare two users' first commits.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the smallest useful version of the feature.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional notes on other approaches.
+  - type: checkboxes
+    id: readiness
+    attributes:
+      label: Readiness
+      options:
+        - label: This can be shipped without adding accounts, a database, or paid services.
+          required: false
+        - label: This needs new tests.
+          required: true

--- a/.github/ISSUE_TEMPLATE/maintenance_task.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance_task.yml
@@ -1,0 +1,34 @@
+name: Maintenance task
+description: Track production, dependency, documentation, or workflow work.
+title: "chore: "
+labels:
+  - maintenance
+body:
+  - type: textarea
+    id: task
+    attributes:
+      label: Task
+      description: What needs to be done?
+      placeholder: Update dependencies and verify CI.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this is done?
+      placeholder: |
+        - CI passes
+        - Deployed smoke passes
+        - Runbook is updated if needed
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: No secrets or environment-specific values are committed.
+          required: true
+        - label: Tests or documentation are updated when behavior changes.
+          required: true

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ A GitHub-themed web application that discovers your origin story on GitHub. Ente
 
 - **Origin Discovery:** Uses the GitHub Search API to find the earliest public commits for any user.
 - **Visual Timeline:** Displays a sequence of the first 10 commits, connected by a vertical line with GitHub-style contribution squares.
+- **Recent Searches:** Keeps successful searches as local browser shortcuts for quick reruns.
+- **Shareable Searches:** Updates the URL with the searched username so results can be shared.
 - **GitHub Aesthetic:** Fully themed with GitHub's color palette, typography, and iconography.
 - **Responsive Design:** Optimized for both desktop and mobile viewing.
+- **Production Checks:** Uses CI, deployed smoke tests, Vercel Analytics, and structured server logs.
 
 ## Getting Started
 
@@ -87,9 +90,11 @@ npm run test:watch
 
 - Set `GITHUB_TOKEN` in the production environment to avoid GitHub's low unauthenticated search rate limit.
 - The token is only used server-side by the GitHub API client and is not exposed to the browser.
-- Usernames entered into the search field are sent to GitHub to retrieve public commit data; the app does not store searches.
+- Usernames entered into the search field are sent to GitHub to retrieve public commit data.
+- Successful searches are stored only in the user's browser `localStorage` as recent-search shortcuts. The app does not store searches on a server.
 - CI runs on every push and pull request to `main`.
 - Production deployment smoke tests run after a successful Vercel deployment using the `PRODUCTION_BASE_URL` repository variable, and can also be started manually from GitHub Actions.
+- Vercel Analytics is enabled in the root layout. Use Vercel Analytics for traffic and Vercel Logs for runtime errors.
 - See the [production runbook](docs/production.md) for deployment checks, observability, and troubleshooting.
 
 ## Deployment
@@ -116,6 +121,14 @@ NEXT_PUBLIC_SITE_URL=https://my-first-commit-eta.vercel.app
 - **API Client:** [Octokit](https://github.com/octokit/octokit.js)
 - **Icons:** [React Icons](https://react-icons.github.io/react-icons/)
 - **Date Handling:** [date-fns](https://date-fns.org/)
+- **Monitoring:** [Vercel Analytics](https://vercel.com/analytics), Vercel Logs, and GitHub Actions
+
+## Maintenance Workflow
+
+- Open feature, fix, and maintenance work as pull requests.
+- Keep PRs focused and wait for CI, Vercel preview, and Copilot review.
+- Use the issue templates for bugs, feature ideas, and maintenance tasks.
+- Merge dependency updates one at a time when possible.
 
 ## License
 

--- a/app/actions.test.ts
+++ b/app/actions.test.ts
@@ -73,12 +73,15 @@ describe("getCommits", () => {
 
     await getCommits("octo");
 
-    expect(searchCommits).toHaveBeenCalledWith({
+    expect(searchCommits).toHaveBeenCalledWith(expect.objectContaining({
       q: "author:octo",
       sort: "committer-date",
       order: "asc",
       per_page: 10,
-    });
+      request: {
+        signal: expect.any(AbortSignal),
+      },
+    }));
   });
 
   it("maps GitHub commit search results into display data", async () => {
@@ -202,6 +205,44 @@ describe("getCommits", () => {
     });
   });
 
+  it("returns a friendly timeout message when GitHub does not respond in time", async () => {
+    const error = new Error("The operation was aborted");
+    error.name = "AbortError";
+    searchCommits.mockRejectedValue(error);
+
+    await expect(getCommits("octo")).resolves.toEqual({
+      found: false,
+      error: "GitHub took too long to respond. Please try again.",
+      errorKind: "timeout",
+      commits: [],
+    });
+    expect(console.warn).toHaveBeenCalledWith({
+      event: "github_commit_search_timeout",
+      status: undefined,
+      message: "The operation was aborted",
+    });
+  });
+
+  it("returns a friendly unavailable message for GitHub 5xx errors", async () => {
+    const error = {
+      status: 503,
+      message: "Service Unavailable",
+    };
+    searchCommits.mockRejectedValue(error);
+
+    await expect(getCommits("octo")).resolves.toEqual({
+      found: false,
+      error: "GitHub is temporarily unavailable. Please try again soon.",
+      errorKind: "unavailable",
+      commits: [],
+    });
+    expect(console.error).toHaveBeenCalledWith({
+      event: "github_commit_search_unavailable",
+      status: 503,
+      message: "Service Unavailable",
+    }, error);
+  });
+
   it("does not classify non-rate-limit GitHub 403 errors as rate limits", async () => {
     const error = {
       status: 403,
@@ -221,6 +262,50 @@ describe("getCommits", () => {
       status: 403,
       message: "Resource not accessible by integration",
     }, error);
+  });
+
+  it("ignores malformed GitHub commit items before deciding whether results exist", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [
+          {
+            ...commitItem,
+            sha: "",
+          },
+          commitItem,
+        ],
+      },
+    });
+
+    const result = await getCommits("octo");
+
+    expect(result.found).toBe(true);
+    expect(result.commits).toHaveLength(1);
+    expect(result.commits[0].sha).toBe("abcdef123456");
+    expect(console.warn).toHaveBeenCalledWith({
+      event: "github_commit_search_malformed_item",
+      itemIndex: 0,
+    });
+  });
+
+  it("returns an empty state when GitHub only returns malformed commit items", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [
+          {
+            ...commitItem,
+            html_url: "",
+          },
+        ],
+      },
+    });
+
+    await expect(getCommits("octo")).resolves.toEqual({
+      found: false,
+      error: "No public commits found for this user (or indexing is delayed).",
+      errorKind: "empty",
+      commits: [],
+    });
   });
 
   it("returns a validation message for GitHub 422 errors", async () => {

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -7,6 +7,8 @@ const octokit = new Octokit({
     auth: process.env.GITHUB_TOKEN 
 });
 
+const GITHUB_SEARCH_TIMEOUT_MS = 10_000;
+
 type GitHubErrorDetails = {
   message?: string;
   rateLimitRemaining?: string;
@@ -34,7 +36,7 @@ export interface CommitInfo {
 export interface CommitData {
   found: boolean;
   error?: string;
-  errorKind?: "empty" | "rate_limit" | "validation" | "unknown";
+  errorKind?: "empty" | "rate_limit" | "timeout" | "unavailable" | "validation" | "unknown";
   commits: CommitInfo[];
 }
 
@@ -72,16 +74,112 @@ function isGitHubRateLimitError(errorDetails: GitHubErrorDetails) {
     && /rate limit|too many requests/i.test(errorDetails.message ?? "");
 }
 
+function isTimeoutError(error: unknown, errorDetails: GitHubErrorDetails) {
+  if (typeof error === "object" && error !== null && "name" in error && error.name === "AbortError") {
+    return true;
+  }
+
+  return /aborted|timeout|timed out/i.test(errorDetails.message ?? "");
+}
+
+function isGitHubUnavailableError(errorDetails: GitHubErrorDetails) {
+  return typeof errorDetails.status === "number"
+    && errorDetails.status >= 500
+    && errorDetails.status < 600;
+}
+
+function withTimeoutSignal<T>(callback: (signal: AbortSignal) => Promise<T>) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), GITHUB_SEARCH_TIMEOUT_MS);
+
+  return Promise.resolve()
+    .then(() => callback(controller.signal))
+    .finally(() => clearTimeout(timeout));
+}
+
+function mapCommitItem(item: unknown, username: string): CommitInfo | null {
+  if (typeof item !== "object" || item === null) return null;
+
+  const candidate = item as {
+    commit?: {
+      message?: unknown;
+      author?: { date?: unknown } | null;
+      committer?: { date?: unknown } | null;
+    };
+    html_url?: unknown;
+    sha?: unknown;
+    repository?: {
+      name?: unknown;
+      full_name?: unknown;
+      owner?: { login?: unknown } | null;
+    };
+    author?: {
+      login?: unknown;
+      avatar_url?: unknown;
+      html_url?: unknown;
+    } | null;
+  };
+  const message = candidate.commit?.message;
+  const htmlUrl = candidate.html_url;
+  const sha = candidate.sha;
+  const repositoryName = candidate.repository?.name;
+  const repositoryFullName = candidate.repository?.full_name;
+  const repositoryOwner = candidate.repository?.owner?.login;
+
+  if (
+    typeof message !== "string"
+    || typeof htmlUrl !== "string"
+    || !htmlUrl
+    || typeof sha !== "string"
+    || !sha
+    || typeof repositoryName !== "string"
+    || typeof repositoryFullName !== "string"
+    || typeof repositoryOwner !== "string"
+  ) {
+    return null;
+  }
+
+  const authorDate = candidate.commit?.author?.date;
+  const committerDate = candidate.commit?.committer?.date;
+  const authorLogin = candidate.author?.login;
+  const authorAvatarUrl = candidate.author?.avatar_url;
+  const authorHtmlUrl = candidate.author?.html_url;
+
+  return {
+    message,
+    date: typeof authorDate === "string"
+      ? authorDate
+      : typeof committerDate === "string"
+        ? committerDate
+        : "",
+    html_url: htmlUrl,
+    sha,
+    repository: {
+      name: repositoryName,
+      owner: repositoryOwner,
+      full_name: repositoryFullName,
+    },
+    author: {
+      login: typeof authorLogin === "string" ? authorLogin : username,
+      avatar_url: typeof authorAvatarUrl === "string" ? authorAvatarUrl : "https://github.com/ghost.png",
+      html_url: typeof authorHtmlUrl === "string" ? authorHtmlUrl : `https://github.com/${username}`,
+    },
+  };
+}
+
 export async function getCommits(username: string): Promise<CommitData> {
   if (!username) return { found: false, error: "Username is required", errorKind: "validation", commits: [] };
 
   try {
-    const response = await octokit.rest.search.commits({
+    const response = await withTimeoutSignal((signal) => octokit.rest.search.commits({
       q: `author:${username}`,
       sort: 'committer-date',
       order: 'asc',
-      per_page: 10
-    });
+      per_page: 10,
+      request: {
+        signal,
+      },
+    }));
 
     const items = response.data.items;
 
@@ -94,22 +192,27 @@ export async function getCommits(username: string): Promise<CommitData> {
       };
     }
 
-    const commits = items.map(item => ({
-        message: item.commit.message,
-        date: item.commit.author?.date || item.commit.committer?.date || "",
-        html_url: item.html_url,
-        sha: item.sha,
-        repository: {
-          name: item.repository.name,
-          owner: item.repository.owner.login,
-          full_name: item.repository.full_name
+    const commits = items.flatMap((item, itemIndex) => {
+      const commit = mapCommitItem(item, username);
+      if (commit) return [commit];
+
+      logger.warn({
+        event: "github_commit_search_malformed_item",
+        fields: {
+          itemIndex,
         },
-        author: {
-          login: item.author?.login || username,
-          avatar_url: item.author?.avatar_url || "https://github.com/ghost.png",
-          html_url: item.author?.html_url || `https://github.com/${username}`
-        }
-    }));
+      });
+      return [];
+    });
+
+    if (commits.length === 0) {
+      return {
+        found: false,
+        error: "No public commits found for this user (or indexing is delayed).",
+        errorKind: "empty",
+        commits: [],
+      };
+    }
 
     return {
       found: true,
@@ -120,6 +223,18 @@ export async function getCommits(username: string): Promise<CommitData> {
     let errorMessage = "Failed to fetch commits.";
     const errorDetails = getGitHubErrorDetails(error);
     const { status } = errorDetails;
+
+    if (isTimeoutError(error, errorDetails)) {
+      logger.warn({
+        event: "github_commit_search_timeout",
+        fields: {
+          status: typeof status === "number" ? status : undefined,
+          message: errorDetails.message,
+        },
+      });
+      errorMessage = "GitHub took too long to respond. Please try again.";
+      return { found: false, error: errorMessage, errorKind: "timeout", commits: [] };
+    }
 
     if (isGitHubRateLimitError(errorDetails)) {
       logger.warn({
@@ -133,7 +248,21 @@ export async function getCommits(username: string): Promise<CommitData> {
       });
       errorMessage = "GitHub rate limit reached. Please try again in a few minutes.";
       return { found: false, error: errorMessage, errorKind: "rate_limit", commits: [] };
-    } else {
+    }
+
+    if (isGitHubUnavailableError(errorDetails)) {
+      logger.error({
+        event: "github_commit_search_unavailable",
+        fields: {
+          status: typeof status === "number" ? status : undefined,
+          message: errorDetails.message,
+        },
+      }, error);
+      errorMessage = "GitHub is temporarily unavailable. Please try again soon.";
+      return { found: false, error: errorMessage, errorKind: "unavailable", commits: [] };
+    }
+
+    {
       logger.error({
         event: "github_commit_search_failed",
         fields: {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Home from "./page";
 import { getCommits } from "./actions";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./actions", () => ({
   getCommits: vi.fn(),
@@ -37,6 +37,10 @@ describe("Home", () => {
     mockGetCommits.mockReset();
     window.localStorage.clear();
     window.history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("focuses the GitHub search field and marks it as a non-credential search box", () => {
@@ -116,6 +120,21 @@ describe("Home", () => {
     const recentSearch = screen.getByRole("button", { name: /search octo again/i });
     expect(recentSearch).toBeInTheDocument();
     expect(JSON.parse(window.localStorage.getItem("my-first-commit:recent-searches") ?? "[]")).toEqual(["octo"]);
+  });
+
+  it("keeps successful searches working when local storage writes fail", async () => {
+    mockGetCommits.mockResolvedValue(commitResult);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("Storage is unavailable");
+    });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(await screen.findByRole("link", { name: "Initial commit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /search another user/i })).toBeInTheDocument();
   });
 
   it("lets users rerun a recent search from local storage", async () => {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -35,6 +35,7 @@ const commitResult = {
 describe("Home", () => {
   beforeEach(() => {
     mockGetCommits.mockReset();
+    window.localStorage.clear();
     window.history.replaceState(null, "", "/");
   });
 
@@ -99,6 +100,54 @@ describe("Home", () => {
 
     expect(window.location.search).toBe("");
     expect(screen.getByRole("searchbox", { name: /github username/i })).toHaveValue("");
+  });
+
+  it("saves successful searches as recent local shortcuts", async () => {
+    mockGetCommits.mockResolvedValue(commitResult);
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    await screen.findByRole("button", { name: /search another user/i });
+
+    await user.click(screen.getByRole("button", { name: /search another user/i }));
+
+    const recentSearch = screen.getByRole("button", { name: /search octo again/i });
+    expect(recentSearch).toBeInTheDocument();
+    expect(JSON.parse(window.localStorage.getItem("my-first-commit:recent-searches") ?? "[]")).toEqual(["octo"]);
+  });
+
+  it("lets users rerun a recent search from local storage", async () => {
+    window.localStorage.setItem("my-first-commit:recent-searches", JSON.stringify(["octo"]));
+    mockGetCommits.mockResolvedValue(commitResult);
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.click(await screen.findByRole("button", { name: /search octo again/i }));
+
+    await waitFor(() => {
+      expect(mockGetCommits).toHaveBeenCalledWith("octo");
+    });
+    expect(window.location.search).toBe("?user=octo");
+  });
+
+  it("does not save failed searches as recent local shortcuts", async () => {
+    mockGetCommits.mockResolvedValue({
+      found: false,
+      error: "No public commits found for this user (or indexing is delayed).",
+      errorKind: "empty",
+      commits: [],
+    });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "new-user");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    await screen.findByRole("heading", { name: /no public commits found/i });
+
+    expect(screen.queryByRole("button", { name: /search new-user again/i })).not.toBeInTheDocument();
+    expect(window.localStorage.getItem("my-first-commit:recent-searches")).toBeNull();
   });
 
   it("shows a username format hint before the user types", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,7 +55,13 @@ function getStoredRecentSearches() {
 }
 
 function saveStoredRecentSearches(searches: string[]) {
-  window.localStorage.setItem(RECENT_SEARCHES_STORAGE_KEY, JSON.stringify(searches));
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(RECENT_SEARCHES_STORAGE_KEY, JSON.stringify(searches));
+  } catch {
+    // Recent searches are a convenience only; searches should still succeed without storage.
+  }
 }
 
 export default function Home() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,9 @@ import { getCommits, CommitData } from './actions';
 import FirstCommitDisplay from '@/components/FirstCommitDisplay';
 import { FaGithub } from "react-icons/fa";
 
+const RECENT_SEARCHES_STORAGE_KEY = "my-first-commit:recent-searches";
+const MAX_RECENT_SEARCHES = 5;
+
 function getUsernameValidationMessage(value: string) {
   const username = value.trim();
 
@@ -36,18 +39,58 @@ function getInitialSharedUsername() {
   return new URLSearchParams(window.location.search).get("user") ?? "";
 }
 
+function getStoredRecentSearches() {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const storedSearches = JSON.parse(window.localStorage.getItem(RECENT_SEARCHES_STORAGE_KEY) ?? "[]");
+    if (!Array.isArray(storedSearches)) return [];
+
+    return storedSearches
+      .filter((search): search is string => typeof search === "string" && !getUsernameValidationMessage(search))
+      .slice(0, MAX_RECENT_SEARCHES);
+  } catch {
+    return [];
+  }
+}
+
+function saveStoredRecentSearches(searches: string[]) {
+  window.localStorage.setItem(RECENT_SEARCHES_STORAGE_KEY, JSON.stringify(searches));
+}
+
 export default function Home() {
   const [username, setUsername] = useState(getInitialSharedUsername);
   const [result, setResult] = useState<CommitData | null>(null);
   const [lastSearchedUsername, setLastSearchedUsername] = useState('');
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [isPending, startTransition] = useTransition();
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const loadRecentSearches = window.setTimeout(() => {
+      setRecentSearches(getStoredRecentSearches());
+    }, 0);
+
+    return () => window.clearTimeout(loadRecentSearches);
+  }, []);
 
   useEffect(() => {
     if (!result?.found) {
       searchInputRef.current?.focus();
     }
   }, [result?.found]);
+
+  const rememberRecentSearch = useCallback((searchedUsername: string) => {
+    setRecentSearches((currentSearches) => {
+      const nextSearches = [
+        searchedUsername,
+        ...currentSearches.filter((search) => search.toLowerCase() !== searchedUsername.toLowerCase()),
+      ].slice(0, MAX_RECENT_SEARCHES);
+
+      saveStoredRecentSearches(nextSearches);
+      return nextSearches;
+    });
+  }, []);
 
   const searchCommits = useCallback((searchUsername: string, options: { updateUrl?: boolean } = {}) => {
     const trimmedUsername = searchUsername.trim();
@@ -59,8 +102,11 @@ export default function Home() {
     startTransition(async () => {
        const data = await getCommits(trimmedUsername);
        setResult(data);
+       if (data.found) {
+        rememberRecentSearch(trimmedUsername);
+       }
     });
-  }, []);
+  }, [rememberRecentSearch]);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -176,6 +222,30 @@ export default function Home() {
                 {isPending ? 'Searching...' : 'Search'}
             </button>
         </form>
+        )}
+
+        {!result?.found && recentSearches.length > 0 && (
+            <section aria-labelledby="recent-searches-heading" className="mt-4 w-full max-w-md">
+                <h2 id="recent-searches-heading" className="text-xs font-semibold uppercase tracking-normal text-[var(--github-gray-text)]">
+                    Recent searches
+                </h2>
+                <div className="mt-2 flex flex-wrap gap-2">
+                    {recentSearches.map((recentUsername) => (
+                        <button
+                            key={recentUsername}
+                            type="button"
+                            onClick={() => {
+                                setUsername(recentUsername);
+                                searchCommits(recentUsername, { updateUrl: true });
+                            }}
+                            className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+                            aria-label={`Search ${recentUsername} again`}
+                        >
+                            @{recentUsername}
+                        </button>
+                    ))}
+                </div>
+            </section>
         )}
 
         {isPending && !result && (

--- a/docs/production.md
+++ b/docs/production.md
@@ -119,7 +119,10 @@ In Vercel:
 GitHub API failures are logged with structured event names:
 
 - `github_commit_search_rate_limited`
+- `github_commit_search_timeout`
+- `github_commit_search_unavailable`
 - `github_commit_search_failed`
+- `github_commit_search_malformed_item`
 
 Useful fields include:
 
@@ -127,8 +130,19 @@ Useful fields include:
 - `message`
 - `rateLimitRemaining`
 - `rateLimitReset`
+- `itemIndex`
 
 Search usernames and tokens should not appear in logs.
+
+## Privacy And Local Storage
+
+The app does not persist searches on a server. Successful searches are stored in the user's browser `localStorage` under:
+
+```text
+my-first-commit:recent-searches
+```
+
+This powers the recent-search shortcuts. Clearing browser site data removes the list.
 
 ## Troubleshooting
 
@@ -153,6 +167,18 @@ Confirm `GITHUB_TOKEN` is set in Vercel production. Unauthenticated GitHub Searc
 ### GitHub Searches Fail With Validation Errors
 
 Check logs for `github_commit_search_failed` with `status: 422`. This usually means the username/query is invalid or GitHub could not validate the search request.
+
+### GitHub Searches Time Out
+
+Check logs for `github_commit_search_timeout`. This means GitHub did not respond before the server action timeout. Retry the search and check GitHub status if it persists.
+
+### GitHub Is Temporarily Unavailable
+
+Check logs for `github_commit_search_unavailable` with a `5xx` status. The app should show a retry-friendly message. Wait for GitHub to recover or retry later.
+
+### GitHub Returns Unexpected Commit Data
+
+Check logs for `github_commit_search_malformed_item`. The app skips malformed records and shows an empty state if no valid commits remain.
 
 ### Production Works But Preview Fails
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -47,6 +47,17 @@ test("home page blocks invalid usernames without leaving keyboard flow", async (
   await expect(searchBox).toBeFocused();
 });
 
+test("home page renders recent searches stored in the browser", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("my-first-commit:recent-searches", JSON.stringify(["octocat"]));
+  });
+
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Recent searches" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Search octocat again" })).toBeVisible();
+});
+
 test("home page advertises branded app and social preview images", async ({ page, request }) => {
   await page.goto("/");
 


### PR DESCRIPTION
## Summary
Round out the app with production-friendly resilience, local recent-search shortcuts, monitoring/runbook documentation, and GitHub issue templates.

## Changes
- Add timeout, GitHub 5xx, and malformed commit response handling in the server action.
- Log timeout, unavailable, and malformed-item events without logging searched usernames or tokens.
- Add recent-search shortcuts stored only in browser localStorage after successful searches.
- Document Vercel Analytics/logging, local storage behavior, troubleshooting, and maintenance workflow.
- Add GitHub issue templates for bugs, feature requests, and maintenance tasks.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm audit
  - npm test
  - npm run lint
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #