### PR TITLE
ci(workflows): rename production health check

### DIFF
--- a/.github/workflows/deployed-smoke.yml
+++ b/.github/workflows/deployed-smoke.yml
@@ -1,4 +1,4 @@
-name: Deployed Smoke
+name: Production Health Check
 
 on:
   deployment_status:
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   smoke:
-    name: Playwright deployed smoke
+    name: Playwright production health check
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
@@ -57,19 +57,19 @@ jobs:
               ;;
           esac
 
-      - name: Run deployed browser smoke tests
+      - name: Run production browser health checks
         run: npm run test:e2e
 
-      - name: Create or update smoke failure issue
+      - name: Create or update health check failure issue
         if: failure() && github.event_name == 'deployment_status'
         env:
           GH_TOKEN: ${{ github.token }}
           SMOKE_TARGET: ${{ env.PLAYWRIGHT_BASE_URL }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          issue_title="Production smoke test failed"
+          issue_title="Production health check failed"
           issue_body="$(cat <<BODY
-          The production smoke test failed.
+          The production health check failed.
 
           - Target: ${SMOKE_TARGET}
           - Workflow run: ${RUN_URL}

--- a/.github/workflows/deployed-smoke.yml
+++ b/.github/workflows/deployed-smoke.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       base_url:
-        description: Fully qualified deployed app URL to smoke test.
+        description: Fully qualified deployed app URL to health check.
         required: true
 
 permissions:
@@ -41,7 +41,7 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Validate smoke target
+      - name: Validate health check target
         run: |
           if [ -z "$PLAYWRIGHT_BASE_URL" ]; then
             echo "PLAYWRIGHT_BASE_URL is required."

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A GitHub-themed web application that discovers your origin story on GitHub. Ente
 - **Shareable Searches:** Updates the URL with the searched username so results can be shared.
 - **GitHub Aesthetic:** Fully themed with GitHub's color palette, typography, and iconography.
 - **Responsive Design:** Optimized for both desktop and mobile viewing.
-- **Production Checks:** Uses CI, deployed smoke tests, Vercel Analytics, and structured server logs.
+- **Production Checks:** Uses CI, production health checks, Vercel Analytics, and structured server logs.
 
 ## Getting Started
 
@@ -78,7 +78,7 @@ Or point the smoke test at any deployed URL:
 PLAYWRIGHT_BASE_URL=https://your-deployment.example npm run test:e2e
 ```
 
-Production deployments also trigger the deployed smoke test automatically through the `Deployed Smoke` GitHub Actions workflow. Set the `PRODUCTION_BASE_URL` GitHub Actions repository variable to the public production URL. Manual runs of that workflow require a deployed URL.
+Production deployments also trigger the `Production Health Check` GitHub Actions workflow. Set the `PRODUCTION_BASE_URL` GitHub Actions repository variable to the public production URL. Manual runs of that workflow require a deployed URL.
 
 For active test-driven development:
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ npm run lint
 npm run build
 ```
 
-To run the browser smoke test against the deployed app:
+To run the browser health check against the deployed app:
 
 ```bash
 npm run test:e2e:deployed
 ```
 
-Or point the smoke test at any deployed URL:
+Or point the health check at any deployed URL:
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://your-deployment.example npm run test:e2e
@@ -93,7 +93,7 @@ npm run test:watch
 - Usernames entered into the search field are sent to GitHub to retrieve public commit data.
 - Successful searches are stored only in the user's browser `localStorage` as recent-search shortcuts. The app does not store searches on a server.
 - CI runs on every push and pull request to `main`.
-- Production deployment smoke tests run after a successful Vercel deployment using the `PRODUCTION_BASE_URL` repository variable, and can also be started manually from GitHub Actions.
+- Production health checks run after a successful Vercel deployment using the `PRODUCTION_BASE_URL` repository variable, and can also be started manually from GitHub Actions.
 - Vercel Analytics is enabled in the root layout. Use Vercel Analytics for traffic and Vercel Logs for runtime errors.
 - See the [production runbook](docs/production.md) for deployment checks, observability, and troubleshooting.
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -32,16 +32,16 @@ PRODUCTION_BASE_URL=https://my-first-commit-eta.vercel.app
 2. GitHub Actions runs `CI / validate`.
 3. Vercel builds and deploys production.
 4. GitHub receives a production `deployment_status` event.
-5. The `Deployed Smoke` workflow runs Playwright against `PRODUCTION_BASE_URL`.
+5. The `Production Health Check` workflow runs Playwright against `PRODUCTION_BASE_URL`.
 
-The production deploy is healthy when both `CI / validate` and `Deployed Smoke` pass on `main`.
+The production deploy is healthy when both `CI / validate` and `Production Health Check` pass on `main`.
 
-## Production Smoke Alerts
+## Production Health Check Alerts
 
-When `Deployed Smoke` fails, GitHub Actions opens or updates a GitHub issue titled:
+When `Production Health Check` fails, GitHub Actions opens or updates a GitHub issue titled:
 
 ```text
-Production smoke test failed
+Production health check failed
 ```
 
 Use that issue as the incident record. It includes the smoke target, workflow run, and commit SHA.
@@ -52,8 +52,8 @@ When responding to a smoke failure:
 2. Confirm the smoke target is the public production URL.
 3. Open production manually and check whether the app renders.
 4. Fix the deployment, configuration, or app regression.
-5. Re-run `Deployed Smoke` or deploy a fix.
-6. Close the issue after production smoke passes again.
+5. Re-run `Production Health Check` or deploy a fix.
+6. Close the issue after the production health check passes again.
 
 ## Manual Validation
 
@@ -79,7 +79,7 @@ Run a smoke test against any deployed URL:
 PLAYWRIGHT_BASE_URL=https://your-deployment.example npm run test:e2e
 ```
 
-You can also start `Deployed Smoke` manually from GitHub Actions. Provide the public app URL as `base_url`.
+You can also start `Production Health Check` manually from GitHub Actions. Provide the public app URL as `base_url`.
 
 ## Observability
 
@@ -89,7 +89,7 @@ Use these signals together:
 
 - Vercel Analytics for traffic and page-level usage.
 - Vercel Logs for runtime errors and server-side GitHub API failures.
-- GitHub Actions for CI and deployed smoke status.
+- GitHub Actions for CI and production health check status.
 - GitHub issues for production smoke incidents.
 
 ### Vercel Analytics
@@ -146,7 +146,7 @@ This powers the recent-search shortcuts. Clearing browser site data removes the 
 
 ## Troubleshooting
 
-### Deployed Smoke Fails With `401`
+### Production Health Check Fails With `401`
 
 Check the target URL. Vercel-generated deployment URLs can be protected. Confirm the workflow is using:
 
@@ -154,7 +154,7 @@ Check the target URL. Vercel-generated deployment URLs can be protected. Confirm
 PRODUCTION_BASE_URL=https://my-first-commit-eta.vercel.app
 ```
 
-### Deployed Smoke Cannot Find App Text
+### Production Health Check Cannot Find App Text
 
 Open the smoke target URL and confirm it renders the public app. If it shows a login, protection page, or unrelated Vercel page, fix the target URL.
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -7,7 +7,7 @@ This runbook covers the production checks and levers for My First Commit.
 - Public app: https://my-first-commit-eta.vercel.app
 - GitHub repository: https://github.com/scottdensmore/my-first-commit
 
-Use the public app URL for smoke tests. Vercel's generated deployment URLs can be protected and may return `401`.
+Use the public app URL for production health checks. Vercel's generated deployment URLs can be protected and may return `401`.
 
 ## Required Configuration
 
@@ -44,12 +44,12 @@ When `Production Health Check` fails, GitHub Actions opens or updates a GitHub i
 Production health check failed
 ```
 
-Use that issue as the incident record. It includes the smoke target, workflow run, and commit SHA.
+Use that issue as the incident record. It includes the health check target, workflow run, and commit SHA.
 
-When responding to a smoke failure:
+When responding to a health check failure:
 
 1. Open the workflow run linked from the issue.
-2. Confirm the smoke target is the public production URL.
+2. Confirm the health check target is the public production URL.
 3. Open production manually and check whether the app renders.
 4. Fix the deployment, configuration, or app regression.
 5. Re-run `Production Health Check` or deploy a fix.
@@ -67,13 +67,13 @@ npm run build
 npm run test:e2e
 ```
 
-Run a smoke test against production:
+Run a health check against production:
 
 ```bash
 npm run test:e2e:deployed
 ```
 
-Run a smoke test against any deployed URL:
+Run a health check against any deployed URL:
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://your-deployment.example npm run test:e2e
@@ -90,7 +90,7 @@ Use these signals together:
 - Vercel Analytics for traffic and page-level usage.
 - Vercel Logs for runtime errors and server-side GitHub API failures.
 - GitHub Actions for CI and production health check status.
-- GitHub issues for production smoke incidents.
+- GitHub issues for production health check incidents.
 
 ### Vercel Analytics
 
@@ -156,7 +156,7 @@ PRODUCTION_BASE_URL=https://my-first-commit-eta.vercel.app
 
 ### Production Health Check Cannot Find App Text
 
-Open the smoke target URL and confirm it renders the public app. If it shows a login, protection page, or unrelated Vercel page, fix the target URL.
+Open the health check target URL and confirm it renders the public app. If it shows a login, protection page, or unrelated Vercel page, fix the target URL.
 
 ### GitHub Searches Are Rate Limited
 


### PR DESCRIPTION
## Summary
Rename the visible deployed verification workflow from Deployed Smoke to Production Health Check.

## Changes
- Update the GitHub Actions workflow display name and job/step labels.
- Update the production failure issue title/body to use health-check wording.
- Update README and production runbook references.
- Keep the existing workflow filename to avoid unnecessary churn.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing steps:
  - git diff --check

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #