### PR TITLE
docs(readme): add app screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 A GitHub-themed web application that discovers your origin story on GitHub. Enter any username to see their first public commit and the nine that followed, beautifully connected in an activity-graph style timeline.
 
+![My First Commit app screenshot showing a GitHub username search and first commit timeline](display.png)
+
 ## Features
 
 - **Origin Discovery:** Uses the GitHub Search API to find the earliest public commits for any user.


### PR DESCRIPTION
## Summary
Add an app screenshot near the top of the README to make the project page more visual.

## Changes
- Insert the existing display.png screenshot after the intro paragraph.
- Include descriptive alt text for accessibility.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing steps:
  - git diff --check

## Screenshots (if applicable)
Uses existing display.png in the README.

## Related Issues
Closes #