### PR TITLE
docs(readme): split development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ A GitHub-themed web application that discovers your origin story on GitHub. Ente
 
 ![My First Commit app screenshot showing a GitHub username search and first commit timeline](display.png)
 
+## What It Does
+
+My First Commit helps you find the first public GitHub commit for any user. It searches GitHub's public commit index, shows the earliest result first, and includes the next several commits so the timeline feels like a small origin story rather than a single raw link.
+
+The app is intentionally small: no accounts, no database, and no server-side storage of searches. Successful searches are saved only in the user's browser as recent-search shortcuts.
+
 ## Features
 
 - **Origin Discovery:** Uses the GitHub Search API to find the earliest public commits for any user.
@@ -20,107 +26,15 @@ A GitHub-themed web application that discovers your origin story on GitHub. Ente
 - **Responsive Design:** Optimized for both desktop and mobile viewing.
 - **Production Checks:** Uses CI, production health checks, Vercel Analytics, and structured server logs.
 
-## Getting Started
+## Project Links
 
-### Prerequisites
+- **Live app:** [my-first-commit-eta.vercel.app](https://my-first-commit-eta.vercel.app)
+- **Development guide:** [docs/development.md](docs/development.md)
+- **Production runbook:** [docs/production.md](docs/production.md)
 
-- Node.js 22
-- npm
+## How It Works
 
-### Installation
-
-1. Clone the repository:
-   ```bash
-   git clone <repository-url>
-   cd my-first-commit
-   ```
-
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-
-### Configuration (Important)
-
-The application works out of the box using unauthenticated GitHub API requests. However, GitHub imposes a strict rate limit on unauthenticated search requests (10 per minute).
-
-To avoid "Rate limit exceeded" errors, it is highly recommended to use a GitHub Personal Access Token:
-
-1. Create a **Fine-grained personal access token** or a **Tokens (classic)** on GitHub: [Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens).
-2. Create a file named `.env.local` in the root directory.
-3. Add your token to the file:
-   ```env
-   GITHUB_TOKEN=your_github_pat_here
-   ```
-
-### Running Locally
-
-Start the development server:
-
-```bash
-npm run dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) in your browser to explore.
-
-### Validation
-
-Run the same checks used by CI:
-
-```bash
-npm audit
-npm test
-npm run lint
-npm run build
-```
-
-To run the browser health check against the deployed app:
-
-```bash
-npm run test:e2e:deployed
-```
-
-Or point the health check at any deployed URL:
-
-```bash
-PLAYWRIGHT_BASE_URL=https://your-deployment.example npm run test:e2e
-```
-
-Production deployments also trigger the `Production Health Check` GitHub Actions workflow. Set the `PRODUCTION_BASE_URL` GitHub Actions repository variable to the public production URL. Manual runs of that workflow require a deployed URL.
-
-For active test-driven development:
-
-```bash
-npm run test:watch
-```
-
-## Production Notes
-
-- Set `GITHUB_TOKEN` in the production environment to avoid GitHub's low unauthenticated search rate limit.
-- The token is only used server-side by the GitHub API client and is not exposed to the browser.
-- Usernames entered into the search field are sent to GitHub to retrieve public commit data.
-- Successful searches are stored only in the user's browser `localStorage` as recent-search shortcuts. The app does not store searches on a server.
-- CI runs on every push and pull request to `main`.
-- Production health checks run after a successful Vercel deployment using the `PRODUCTION_BASE_URL` repository variable, and can also be started manually from GitHub Actions.
-- Vercel Analytics is enabled in the root layout. Use Vercel Analytics for traffic and Vercel Logs for runtime errors.
-- See the [production runbook](docs/production.md) for deployment checks, observability, and troubleshooting.
-
-## Deployment
-
-This is a standard Next.js app and can be deployed to Vercel or any host that supports Next.js with Node.js 22.
-
-Required production command:
-
-```bash
-npm run build
-```
-
-Recommended environment variable:
-
-```env
-GITHUB_TOKEN=your_github_pat_here
-NEXT_PUBLIC_SITE_URL=https://my-first-commit-eta.vercel.app
-```
+The app is a Next.js App Router project. The browser collects a GitHub username, the server action queries GitHub with Octokit, and the UI renders the first commit in a GitHub-inspired timeline. Search URLs can be shared with `?user=<username>`, and recent searches are stored locally in `localStorage`.
 
 ## Tech Stack
 
@@ -131,12 +45,17 @@ NEXT_PUBLIC_SITE_URL=https://my-first-commit-eta.vercel.app
 - **Date Handling:** [date-fns](https://date-fns.org/)
 - **Monitoring:** [Vercel Analytics](https://vercel.com/analytics), Vercel Logs, and GitHub Actions
 
-## Maintenance Workflow
+## Privacy
 
-- Open feature, fix, and maintenance work as pull requests.
-- Keep PRs focused and wait for CI, Vercel preview, and Copilot review.
-- Use the issue templates for bugs, feature ideas, and maintenance tasks.
-- Merge dependency updates one at a time when possible.
+- Usernames entered into the search field are sent to GitHub to retrieve public commit data.
+- `GITHUB_TOKEN` is used only server-side and is never exposed to the browser.
+- Recent searches are stored only in the user's browser under `my-first-commit:recent-searches`.
+- The app does not store searches on a server.
+
+## Documentation
+
+- Use the [development guide](docs/development.md) for local setup, environment variables, testing, and deployment commands.
+- Use the [production runbook](docs/production.md) for production checks, observability, and troubleshooting.
 
 ## License
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,113 @@
+# Development Guide
+
+This guide covers local setup, configuration, validation, deployment, and maintenance for My First Commit.
+
+## Prerequisites
+
+- Node.js 22
+- npm
+
+## Installation
+
+1. Clone the repository:
+
+   ```bash
+   git clone <repository-url>
+   cd my-first-commit
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+## Configuration
+
+The app works out of the box using unauthenticated GitHub API requests. GitHub applies a strict rate limit to unauthenticated search requests, so a token is recommended for local and production use.
+
+Create `.env.local` in the project root:
+
+```env
+GITHUB_TOKEN=your_github_pat_here
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+```
+
+`GITHUB_TOKEN` is server-side only. Do not expose it as a `NEXT_PUBLIC_*` variable.
+
+## Running Locally
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+## Validation
+
+Run the same core checks used by CI:
+
+```bash
+npm audit
+npm test
+npm run lint
+npm run build
+```
+
+Run the local browser health check:
+
+```bash
+npm run test:e2e
+```
+
+Run the browser health check against production:
+
+```bash
+npm run test:e2e:deployed
+```
+
+Or point the health check at any deployed URL:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://your-deployment.example npm run test:e2e
+```
+
+For active test-driven development:
+
+```bash
+npm run test:watch
+```
+
+## Deployment
+
+This is a standard Next.js app and can be deployed to Vercel or any host that supports Next.js with Node.js 22.
+
+Required production build command:
+
+```bash
+npm run build
+```
+
+Recommended production environment variables:
+
+```env
+GITHUB_TOKEN=your_github_pat_here
+NEXT_PUBLIC_SITE_URL=https://my-first-commit-eta.vercel.app
+```
+
+Production deployments trigger the `Production Health Check` GitHub Actions workflow. Set the `PRODUCTION_BASE_URL` GitHub Actions repository variable to the public production URL:
+
+```env
+PRODUCTION_BASE_URL=https://my-first-commit-eta.vercel.app
+```
+
+See the [production runbook](production.md) for deployment checks, observability, and troubleshooting.
+
+## Maintenance Workflow
+
+- Open feature, fix, and maintenance work as pull requests.
+- Keep PRs focused and wait for CI, Vercel preview, and Copilot review.
+- Use the issue templates for bugs, feature ideas, and maintenance tasks.
+- Merge dependency updates one at a time when possible.


### PR DESCRIPTION
## Summary
Refocus the README on describing the app and move setup/build/test/deployment details into a dedicated development guide.

## Changes
- Keep the README as a project overview with screenshot, features, project links, architecture summary, tech stack, privacy notes, and documentation links.
- Add docs/development.md for prerequisites, installation, configuration, local running, validation, deployment, and maintenance workflow.
- Link README to the new development guide and existing production runbook.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing steps:
  - git diff --check

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #