### PR TITLE
feat(app): add error and not-found pages

### DIFF
--- a/app/error.test.tsx
+++ b/app/error.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import ErrorPage from "./error";
+
+describe("ErrorPage", () => {
+  it("shows a branded recovery screen and lets users retry", async () => {
+    const reset = vi.fn();
+    const user = userEvent.setup();
+    const error = Object.assign(new Error("Unexpected failure"), {
+      digest: "abc123",
+    });
+
+    render(<ErrorPage error={error} reset={reset} />);
+
+    expect(screen.getByRole("heading", { name: /we lost the commit trail/i })).toBeInTheDocument();
+    expect(screen.getByText(/unexpected error/i)).toBeInTheDocument();
+    expect(screen.getByText(/error reference: abc123/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /go home/i })).toHaveAttribute("href", "/");
+
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show an error reference when Next.js does not provide one", () => {
+    render(<ErrorPage error={new Error("Unexpected failure")} reset={vi.fn()} />);
+
+    expect(screen.queryByText(/error reference/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  return (
+    <main className="min-h-screen bg-white text-[var(--github-gray-dark)]">
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col items-center justify-center px-6 py-16 text-center">
+        <p className="text-sm font-semibold uppercase tracking-normal text-[var(--github-gray-text)]">
+          Something went wrong
+        </p>
+        <h1 className="mt-3 text-4xl font-bold sm:text-5xl">
+          We lost the commit trail.
+        </h1>
+        <p className="mt-4 max-w-xl text-lg text-[var(--github-gray-text)]">
+          The app hit an unexpected error. You can try again without losing your place.
+        </p>
+
+        {error.digest && (
+          <p className="mt-4 rounded border border-[var(--github-border)] bg-[var(--github-gray-light)] px-3 py-2 font-mono text-xs text-[var(--github-gray-text)]">
+            Error reference: {error.digest}
+          </p>
+        )}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-md bg-[var(--github-green)] px-5 py-3 text-base font-semibold text-white shadow-sm transition-colors hover:bg-[var(--github-green-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+          >
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="rounded-md border border-[var(--github-border)] px-5 py-3 text-base font-semibold text-[var(--github-gray-dark)] transition-colors hover:bg-[var(--github-gray-light)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/not-found.test.tsx
+++ b/app/not-found.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import NotFound, { metadata } from "./not-found";
+
+describe("NotFound", () => {
+  it("shows a branded 404 page with a path back home", () => {
+    render(<NotFound />);
+
+    expect(metadata.title).toBe("Page not found");
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /this commit path does not exist/i })).toBeInTheDocument();
+    expect(screen.getByText(/link may have been copied incorrectly/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /go home/i })).toHaveAttribute("href", "/");
+  });
+});

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+};
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen bg-white text-[var(--github-gray-dark)]">
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col items-center justify-center px-6 py-16 text-center">
+        <p className="text-sm font-semibold uppercase tracking-normal text-[var(--github-gray-text)]">
+          404
+        </p>
+        <h1 className="mt-3 text-4xl font-bold sm:text-5xl">
+          This commit path does not exist.
+        </h1>
+        <p className="mt-4 max-w-xl text-lg text-[var(--github-gray-text)]">
+          The page may have moved, or the link may have been copied incorrectly.
+        </p>
+        <Link
+          href="/"
+          className="mt-8 rounded-md bg-[var(--github-green)] px-5 py-3 text-base font-semibold text-white shadow-sm transition-colors hover:bg-[var(--github-green-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+        >
+          Go home
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -123,3 +123,11 @@ test("home page advertises branded app and social preview images", async ({ page
   expect(ogResponse.headers()["content-type"]).toContain("image/png");
   expect(twitterResponse.headers()["content-type"]).toContain("image/png");
 });
+
+test("unknown routes show a branded not-found page", async ({ page }) => {
+  const response = await page.goto("/missing-commit-path");
+
+  expect(response?.status()).toBe(404);
+  await expect(page.getByRole("heading", { name: "This commit path does not exist." })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Go home" })).toHaveAttribute("href", "/");
+});


### PR DESCRIPTION
## Summary
Add branded production failure states for unexpected app errors and unknown routes.

## Changes
- Add an App Router error boundary with retry and home actions.
- Add a branded not-found page with metadata and a home link.
- Add unit tests for both new pages.
- Add an e2e check for unknown routes returning the branded 404 page.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm test
  - npm run lint
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #