### PR TITLE
feat(app): add runtime health endpoint

### DIFF
--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+const originalEnv = process.env;
+
+describe("GET /api/health", () => {
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns a no-store health payload without secrets", async () => {
+    process.env = {
+      ...originalEnv,
+      GITHUB_TOKEN: "secret-token",
+      NEXT_PUBLIC_SITE_URL: "https://my-first-commit-eta.vercel.app",
+      VERCEL_ENV: "production",
+      VERCEL_GIT_COMMIT_SHA: "abc123",
+    };
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(body).toMatchObject({
+      status: "ok",
+      service: "my-first-commit",
+      environment: "production",
+      commit: "abc123",
+      checks: {
+        siteUrl: {
+          configured: true,
+          value: "https://my-first-commit-eta.vercel.app",
+        },
+      },
+    });
+    expect(Date.parse(body.timestamp)).not.toBeNaN();
+    expect(JSON.stringify(body)).not.toContain("secret-token");
+  });
+
+  it("reports missing optional public configuration without failing health", async () => {
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SITE_URL: "",
+      VERCEL_ENV: "",
+      VERCEL_GIT_COMMIT_SHA: "",
+    };
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "ok",
+      environment: "local",
+      commit: "local",
+      checks: {
+        siteUrl: {
+          configured: false,
+          value: null,
+        },
+      },
+    });
+  });
+});

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,53 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type HealthPayload = {
+  status: "ok";
+  service: "my-first-commit";
+  timestamp: string;
+  environment: string;
+  commit: string;
+  runtime: {
+    node: string;
+  };
+  checks: {
+    siteUrl: {
+      configured: boolean;
+      value: string | null;
+    };
+  };
+};
+
+function getPublicSiteUrl() {
+  return process.env.NEXT_PUBLIC_SITE_URL?.trim() || null;
+}
+
+export function buildHealthPayload(now = new Date()): HealthPayload {
+  const siteUrl = getPublicSiteUrl();
+
+  return {
+    status: "ok",
+    service: "my-first-commit",
+    timestamp: now.toISOString(),
+    environment: process.env.VERCEL_ENV?.trim() || "local",
+    commit: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || "local",
+    runtime: {
+      node: process.version,
+    },
+    checks: {
+      siteUrl: {
+        configured: Boolean(siteUrl),
+        value: siteUrl,
+      },
+    },
+  };
+}
+
+export async function GET() {
+  return Response.json(buildHealthPayload(), {
+    status: 200,
+    headers: {
+      "Cache-Control": "no-store, max-age=0",
+    },
+  });
+}

--- a/docs/production.md
+++ b/docs/production.md
@@ -9,6 +9,14 @@ This runbook covers the production checks and levers for My First Commit.
 
 Use the public app URL for production health checks. Vercel's generated deployment URLs can be protected and may return `401`.
 
+The app also exposes a lightweight runtime health endpoint:
+
+```text
+https://my-first-commit-eta.vercel.app/api/health
+```
+
+It returns JSON status, deployment metadata, Node runtime version, and whether the public site URL is configured. It does not expose server-side secrets.
+
 ## Required Configuration
 
 Vercel environment variables:
@@ -71,6 +79,12 @@ Run a health check against production:
 
 ```bash
 npm run test:e2e:deployed
+```
+
+Check the runtime health endpoint directly:
+
+```bash
+curl https://my-first-commit-eta.vercel.app/api/health
 ```
 
 Run a health check against any deployed URL:

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -131,3 +131,21 @@ test("unknown routes show a branded not-found page", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "This commit path does not exist." })).toBeVisible();
   await expect(page.getByRole("link", { name: "Go home" })).toHaveAttribute("href", "/");
 });
+
+test("health endpoint reports app status without caching", async ({ request }) => {
+  const response = await request.get("/api/health");
+  const body = await response.json();
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()["cache-control"]).toBe("no-store, max-age=0");
+  expect(body).toMatchObject({
+    status: "ok",
+    service: "my-first-commit",
+    checks: {
+      siteUrl: {
+        configured: expect.any(Boolean),
+      },
+    },
+  });
+  expect(Date.parse(body.timestamp)).not.toBeNaN();
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -134,10 +134,13 @@ test("unknown routes show a branded not-found page", async ({ page }) => {
 
 test("health endpoint reports app status without caching", async ({ request }) => {
   const response = await request.get("/api/health");
-  const body = await response.json();
 
   expect(response.status()).toBe(200);
-  expect(response.headers()["cache-control"]).toBe("no-store, max-age=0");
+  expect(response.headers()["cache-control"]).toContain("no-store");
+  expect(response.headers()["cache-control"]).toContain("max-age=0");
+
+  const body = await response.json();
+
   expect(body).toMatchObject({
     status: "ok",
     service: "my-first-commit",


### PR DESCRIPTION
## Summary
Add a lightweight runtime health endpoint for deployment checks and production troubleshooting.

## Changes
- Add /api/health with no-store JSON status, runtime, deployment metadata, and public config status.
- Add unit tests that verify the payload shape and that secrets are not exposed.
- Add Playwright coverage for the endpoint.
- Document the endpoint in the production runbook.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm test -- --run app/api/health/route.test.ts
  - npm run lint
  - npm test
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #