### PR TITLE
feat(app): add production polish guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@ Thanks for helping improve My First Commit. Keep changes small, tested, and easy
 ## Workflow
 
 1. Start from the latest `main`.
-2. Create a focused branch using the `scottdensmore/` prefix for local work:
+2. Create a focused branch. When working directly in this repository, use your GitHub handle as a branch prefix:
 
    ```bash
    git checkout main
    git pull
-   git checkout -b scottdensmore/<type>/<short-description>
+   git checkout -b <your-github-handle>/<type>/<short-description>
    ```
 
 3. Make one logical change per pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Thanks for helping improve My First Commit. Keep changes small, tested, and easy to review.
+
+## Workflow
+
+1. Start from the latest `main`.
+2. Create a focused branch using the `scottdensmore/` prefix for local work:
+
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b scottdensmore/<type>/<short-description>
+   ```
+
+3. Make one logical change per pull request.
+4. Add or update tests with the change. New behavior should include unit coverage, and user-visible flows should include Playwright coverage when practical.
+5. Run validation before opening a PR:
+
+   ```bash
+   npm test
+   npm run lint
+   npm run build
+   npm run test:e2e
+   ```
+
+6. Open a pull request into `main`.
+7. Wait for CI, Vercel preview, and Copilot review.
+8. Address review comments before merging.
+
+## Pull Requests
+
+- Keep PRs focused and under roughly 400 changed lines when practical.
+- Use Conventional Commit style for titles, for example `feat(app): add runtime health endpoint`.
+- Include what changed, why it changed, and how it was tested.
+- Do not include secrets, debug statements, or unrelated formatting churn.
+
+## Dependency Updates
+
+Dependabot opens dependency PRs. Review and merge them one at a time when possible, after CI passes.
+
+## Production Checks
+
+After a PR merges to `main`, Vercel deploys production and GitHub Actions runs the production health check against the public app URL.
+
+Use the [production runbook](docs/production.md) for deployment checks, observability, and troubleshooting.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The app is intentionally small: no accounts, no database, and no server-side sto
 - **Live app:** [my-first-commit-eta.vercel.app](https://my-first-commit-eta.vercel.app)
 - **Development guide:** [docs/development.md](docs/development.md)
 - **Production runbook:** [docs/production.md](docs/production.md)
+- **Contributing guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## How It Works
 
@@ -63,6 +64,7 @@ The app is a Next.js App Router project. The browser collects a GitHub username,
 
 - Use the [development guide](docs/development.md) for local setup, environment variables, testing, and deployment commands.
 - Use the [production runbook](docs/production.md) for production checks, observability, and troubleshooting.
+- Use the [contributing guide](CONTRIBUTING.md) for branch, PR, review, and validation workflow.
 
 ## License
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -345,18 +345,21 @@ describe("Home", () => {
       errorKind: "timeout" as const,
       heading: /github took too long to respond/i,
       details: /request timed out/i,
+      canRetry: true,
     },
     {
       errorKind: "unavailable" as const,
       heading: /github search is temporarily unavailable/i,
       details: /temporary service error/i,
+      canRetry: true,
     },
     {
       errorKind: "validation" as const,
       heading: /github could not validate that search/i,
       details: /check the username/i,
+      canRetry: false,
     },
-  ])("renders specific recovery copy for $errorKind errors", async ({ errorKind, heading, details }) => {
+  ])("renders specific recovery copy for $errorKind errors", async ({ errorKind, heading, details, canRetry }) => {
     mockGetCommits.mockResolvedValue({
       found: false,
       error: "Search failed.",
@@ -371,6 +374,28 @@ describe("Home", () => {
 
     expect(await screen.findByRole("heading", { name: heading })).toBeInTheDocument();
     expect(screen.getByText(details)).toBeInTheDocument();
+    if (canRetry) {
+      expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+    } else {
+      expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument();
+    }
+  });
+
+  it("shows a retry action for unknown GitHub errors", async () => {
+    mockGetCommits.mockResolvedValue({
+      found: false,
+      error: "GitHub commit search failed. Please try again.",
+      errorKind: "unknown",
+      commits: [],
+    });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(await screen.findByRole("heading", { name: /we could not complete that search/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 
   it("retries the username that produced a rate-limit error", async () => {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -336,8 +336,41 @@ describe("Home", () => {
 
     expect(await screen.findByRole("heading", { name: /github is asking us to slow down/i })).toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent(/github is asking us to slow down/i);
-    expect(screen.getByText(/wait a few minutes/i)).toBeInTheDocument();
+    expect(screen.getByText(/temporarily limited commit search requests/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      errorKind: "timeout" as const,
+      heading: /github took too long to respond/i,
+      details: /request timed out/i,
+    },
+    {
+      errorKind: "unavailable" as const,
+      heading: /github search is temporarily unavailable/i,
+      details: /temporary service error/i,
+    },
+    {
+      errorKind: "validation" as const,
+      heading: /github could not validate that search/i,
+      details: /check the username/i,
+    },
+  ])("renders specific recovery copy for $errorKind errors", async ({ errorKind, heading, details }) => {
+    mockGetCommits.mockResolvedValue({
+      found: false,
+      error: "Search failed.",
+      errorKind,
+      commits: [],
+    });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(await screen.findByRole("heading", { name: heading })).toBeInTheDocument();
+    expect(screen.getByText(details)).toBeInTheDocument();
   });
 
   it("retries the username that produced a rate-limit error", async () => {
@@ -404,6 +437,8 @@ describe("Home", () => {
 
     expect(screen.getByText("My First Commit")).toBeInTheDocument();
     expect(screen.queryByText(/MyFirstCommit Clone/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/recent searches stay in this browser only/i)).toBeInTheDocument();
+    expect(screen.getByText(/not stored on this app's server/i)).toBeInTheDocument();
     expect(screen.getByText(/Not affiliated with GitHub/i)).toBeInTheDocument();
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,6 +74,41 @@ function clearStoredRecentSearches() {
   }
 }
 
+function getResultMessage(result: CommitData) {
+  switch (result.errorKind) {
+    case "rate_limit":
+      return {
+        title: "GitHub is asking us to slow down.",
+        description: "GitHub temporarily limited commit search requests. Wait a few minutes, then try this username again.",
+      };
+    case "timeout":
+      return {
+        title: "GitHub took too long to respond.",
+        description: "The request timed out before GitHub finished searching. Try again now, or give GitHub a moment if it keeps happening.",
+      };
+    case "unavailable":
+      return {
+        title: "GitHub search is temporarily unavailable.",
+        description: "GitHub returned a temporary service error. Your search is safe to retry once GitHub recovers.",
+      };
+    case "validation":
+      return {
+        title: "GitHub could not validate that search.",
+        description: "Check the username and try again. GitHub may reject searches for users that do not exist or cannot be searched.",
+      };
+    case "empty":
+      return {
+        title: "No public commits found.",
+        description: "Try another username or check back later; GitHub commit search indexing can lag.",
+      };
+    default:
+      return {
+        title: "We could not complete that search.",
+        description: result.error ?? "GitHub commit search failed. Please try again.",
+      };
+  }
+}
+
 export default function Home() {
   const [username, setUsername] = useState(getInitialSharedUsername);
   const [result, setResult] = useState<CommitData | null>(null);
@@ -152,9 +187,12 @@ export default function Home() {
     return () => window.clearTimeout(autoSearch);
   }, [searchCommits]);
 
-  const errorMessage = result && !result.found ? result.error ?? "User not found or no public commits." : "";
-  const isRateLimited = result?.errorKind === "rate_limit";
   const isEmptyResult = result?.errorKind === "empty";
+  const canRetrySearch = result?.errorKind === "rate_limit"
+    || result?.errorKind === "timeout"
+    || result?.errorKind === "unavailable"
+    || result?.errorKind === "unknown";
+  const resultMessage = result && !result.found ? getResultMessage(result) : null;
   const resultStateRole = isEmptyResult ? "status" : "alert";
   const usernameValidationMessage = getUsernameValidationMessage(username);
   const usernameDescriptionIds = usernameValidationMessage
@@ -292,17 +330,13 @@ export default function Home() {
         {result && !result.found && (
             <div role={resultStateRole} aria-live={isEmptyResult ? "polite" : undefined} className={`mt-8 w-full max-w-md rounded-md border p-5 text-left shadow-sm ${isEmptyResult ? 'border-[var(--github-border)] bg-[var(--github-gray-light)] text-[var(--github-gray-dark)]' : 'border-red-200 bg-red-50 text-red-800'}`}>
                 <h2 className="text-base font-semibold text-[var(--github-gray-dark)]">
-                    {isRateLimited ? "GitHub is asking us to slow down." : isEmptyResult ? "No public commits found." : "We could not complete that search."}
+                    {resultMessage?.title}
                 </h2>
                 <p className="mt-2 text-sm text-[var(--github-gray-text)]">
-                    {isRateLimited
-                        ? "Wait a few minutes, then try again. GitHub temporarily limited commit search requests."
-                        : isEmptyResult
-                            ? "Try another username or check back later; GitHub commit search indexing can lag."
-                            : errorMessage}
+                    {resultMessage?.description}
                 </p>
                 <div className="mt-4 flex flex-wrap gap-2">
-                    {isRateLimited && (
+                    {canRetrySearch && (
                         <button
                             type="button"
                             onClick={() => searchCommits(lastSearchedUsername)}
@@ -369,7 +403,10 @@ export default function Home() {
       </main>
 
       {/* Footer */}
-      <footer className="py-6 border-t border-[var(--github-border)] text-center text-xs text-[var(--github-gray-text)] bg-[var(--github-gray-light)]">
+      <footer className="border-t border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-6 text-center text-xs text-[var(--github-gray-text)]">
+        <p className="mx-auto mb-2 max-w-2xl">
+            Privacy: searches are sent to GitHub to find public commits. Recent searches stay in this browser only and are not stored on this app&apos;s server.
+        </p>
         <p>&copy; {new Date().getFullYear()} Not affiliated with GitHub.</p>
       </footer>
     </div>

--- a/docs/production.md
+++ b/docs/production.md
@@ -81,6 +81,8 @@ Run a health check against production:
 npm run test:e2e:deployed
 ```
 
+The deployed browser health check covers the home page, branded 404 page, generated social assets, and `/api/health`.
+
 Check the runtime health endpoint directly:
 
 ```bash


### PR DESCRIPTION
## Summary
Add the next production polish pass: clearer privacy and failure guidance, deployed smoke documentation, and contributor workflow docs.

## Changes
- Add a visible footer privacy note explaining GitHub searches and browser-only recent searches.
- Improve user-facing copy for rate limit, timeout, unavailable, validation, and unknown search failures.
- Allow retry for transient GitHub failures beyond rate limits.
- Document that deployed smoke coverage includes the branded 404 page and health endpoint.
- Add a CONTRIBUTING guide and link it from the README.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm test -- --run app/page.test.tsx
  - npm test
  - npm run lint
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #