### PR TITLE
feat(app): add baseline security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Added
 
+- Baseline security headers for app, API, 404, and generated image responses.
 - Runtime `/api/health` endpoint for deployment checks and production troubleshooting.
 - Branded app error boundary and custom 404 page.
 - Production health check workflow with GitHub issue creation on deployment failures.

--- a/docs/production.md
+++ b/docs/production.md
@@ -170,6 +170,17 @@ Useful fields include:
 
 Search usernames and tokens should not appear in logs.
 
+## Security Headers
+
+The app sets baseline security headers from `next.config.ts`:
+
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy` disabling camera, microphone, geolocation, and payment APIs
+- `X-Frame-Options: DENY`
+
+Content Security Policy is intentionally not enabled yet. Next.js and Vercel Analytics need a carefully tuned policy so production scripts, generated images, and analytics continue to work without weakening the policy into noise.
+
 ## Privacy And Local Storage
 
 The app does not persist searches on a server. Successful searches are stored in the user's browser `localStorage` under:

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,33 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=()",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+];
+
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,4 +1,16 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type APIResponse } from "@playwright/test";
+
+function expectSecurityHeaders(response: APIResponse) {
+  const headers = response.headers();
+
+  expect(headers["x-content-type-options"]).toBe("nosniff");
+  expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+  expect(headers["permissions-policy"]).toContain("camera=()");
+  expect(headers["permissions-policy"]).toContain("microphone=()");
+  expect(headers["permissions-policy"]).toContain("geolocation=()");
+  expect(headers["permissions-policy"]).toContain("payment=()");
+  expect(headers["x-frame-options"]).toBe("DENY");
+}
 
 test("home page search field is keyboard-ready and not treated as a credential field", async ({ page }) => {
   await page.goto("/");
@@ -122,6 +134,23 @@ test("home page advertises branded app and social preview images", async ({ page
   expect(iconResponse.headers()["content-type"]).toContain("image/png");
   expect(ogResponse.headers()["content-type"]).toContain("image/png");
   expect(twitterResponse.headers()["content-type"]).toContain("image/png");
+});
+
+test("app responses include baseline security headers", async ({ request }) => {
+  const homeResponse = await request.get("/");
+  const healthResponse = await request.get("/api/health");
+  const notFoundResponse = await request.get("/missing-commit-path");
+  const ogResponse = await request.get("/opengraph-image");
+
+  expect(homeResponse.ok()).toBe(true);
+  expect(healthResponse.ok()).toBe(true);
+  expect(notFoundResponse.status()).toBe(404);
+  expect(ogResponse.ok()).toBe(true);
+
+  expectSecurityHeaders(homeResponse);
+  expectSecurityHeaders(healthResponse);
+  expectSecurityHeaders(notFoundResponse);
+  expectSecurityHeaders(ogResponse);
 });
 
 test("unknown routes show a branded not-found page", async ({ page }) => {


### PR DESCRIPTION
## Summary
Add baseline response security headers across app, API, 404, and generated image routes.

## Changes
- Add X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and X-Frame-Options from next.config.ts.
- Add Playwright coverage that verifies the headers on home, /api/health, 404, and /opengraph-image responses.
- Document the security headers in the production runbook.
- Update the changelog.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm run lint
  - npm run build
  - npm run test:e2e
  - npm test

## Screenshots (if applicable)
N/A

## Related Issues
N/A