### PR TITLE
feat(app): add accessibility polish checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Added
 
+- Accessibility checks for landmarks, keyboard tab order, and privacy content.
 - Baseline security headers for app, API, 404, and generated image responses.
 - Runtime `/api/health` endpoint for deployment checks and production troubleshooting.
 - Branded app error boundary and custom 404 page.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -203,7 +203,7 @@ export default function Home() {
   return (
     <div className="min-h-screen flex flex-col bg-[var(--background)] font-sans">
       {/* Header */}
-      <header className="sticky top-0 z-50 py-3 px-6 border-b border-[var(--github-border)] bg-[var(--github-gray-light)] flex items-center justify-between backdrop-blur-sm bg-white/80">
+      <header aria-label="Site header" className="sticky top-0 z-50 py-3 px-6 border-b border-[var(--github-border)] bg-[var(--github-gray-light)] flex items-center justify-between backdrop-blur-sm bg-white/80">
          <div className="flex items-center gap-2 font-bold text-xl text-[var(--github-gray-dark)]">
             <FaGithub className="text-3xl" />
             <span>My First Commit</span>
@@ -219,7 +219,7 @@ export default function Home() {
       </header>
 
       {/* Main */}
-      <main className="flex-1 flex flex-col items-center p-4 w-full max-w-4xl mx-auto">
+      <main aria-label="Commit search" className="flex-1 flex flex-col items-center p-4 w-full max-w-4xl mx-auto">
         
         {(!result?.found) && (
             <div className={`text-center mb-8 mt-20 transition-all duration-500 ${isPending ? 'opacity-50' : 'opacity-100'}`}>
@@ -403,7 +403,7 @@ export default function Home() {
       </main>
 
       {/* Footer */}
-      <footer className="border-t border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-6 text-center text-xs text-[var(--github-gray-text)]">
+      <footer aria-label="Privacy and GitHub affiliation" className="border-t border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-6 text-center text-xs text-[var(--github-gray-text)]">
         <p className="mx-auto mb-2 max-w-2xl">
             Privacy: searches are sent to GitHub to find public commits. Recent searches stay in this browser only and are not stored on this app&apos;s server.
         </p>

--- a/docs/production.md
+++ b/docs/production.md
@@ -183,7 +183,7 @@ Content Security Policy is intentionally not enabled yet. Next.js and Vercel Ana
 
 ## Accessibility Checks
 
-The browser health checks include accessibility-oriented coverage for landmarks, search form labels, keyboard tab order, validation announcements, empty/error result announcements, and reachable recovery actions.
+The browser health checks include accessibility-oriented coverage for landmarks, search form labels, keyboard tab order, validation announcements, and reachable search/recent-search actions.
 
 When changing UI structure, confirm:
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -181,6 +181,17 @@ The app sets baseline security headers from `next.config.ts`:
 
 Content Security Policy is intentionally not enabled yet. Next.js and Vercel Analytics need a carefully tuned policy so production scripts, generated images, and analytics continue to work without weakening the policy into noise.
 
+## Accessibility Checks
+
+The browser health checks include accessibility-oriented coverage for landmarks, search form labels, keyboard tab order, validation announcements, empty/error result announcements, and reachable recovery actions.
+
+When changing UI structure, confirm:
+
+1. The header, main content, search form, and footer keep clear accessible names.
+2. The search field receives focus on initial load and after reset/edit actions.
+3. Keyboard users can tab from the search field to primary actions and recent-search controls.
+4. Validation and result states use the appropriate `status` or `alert` role.
+
 ## Privacy And Local Storage
 
 The app does not persist searches on a server. Successful searches are stored in the user's browser `localStorage` under:

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -65,8 +65,12 @@ test("home page tab order keeps primary actions reachable", async ({ page }) => 
   const recentSearchButton = page.getByRole("button", { name: "Search octocat again" });
 
   await expect(searchBox).toBeFocused();
+  await expect(clearButton).toBeVisible();
+  await expect(recentSearchButton).toBeVisible();
 
   await searchBox.pressSequentially("octocat");
+  await expect(searchButton).toBeEnabled();
+
   await page.keyboard.press("Tab");
   await expect(searchButton).toBeFocused();
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -28,7 +28,7 @@ test("home page search field is keyboard-ready and not treated as a credential f
   await expect(searchBox).toHaveAttribute("autocapitalize", "none");
   await expect(searchBox).toHaveAttribute("spellcheck", "false");
 
-  const searchButton = page.getByRole("button", { name: "Search" });
+  const searchButton = page.getByRole("button", { name: "Search", exact: true });
   await expect(searchButton).toBeDisabled();
 
   await searchBox.pressSequentially("octocat");
@@ -39,6 +39,42 @@ test("home page search field is keyboard-ready and not treated as a credential f
   await expect(searchButton).toBeFocused();
 
   await expect(page.getByText(/Not affiliated with GitHub/)).toBeVisible();
+});
+
+test("home page exposes accessible landmarks and privacy content", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("banner", { name: "Site header" })).toBeVisible();
+  await expect(page.getByRole("main", { name: "Commit search" })).toBeVisible();
+  await expect(page.getByRole("search", { name: "GitHub commit search" })).toBeVisible();
+  await expect(page.getByRole("contentinfo", { name: "Privacy and GitHub affiliation" })).toBeVisible();
+  await expect(page.getByText(/recent searches stay in this browser only/i)).toBeVisible();
+});
+
+test("home page tab order keeps primary actions reachable", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("my-first-commit:recent-searches", JSON.stringify(["octocat"]));
+  });
+
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+
+  const searchBox = page.getByRole("searchbox", { name: "GitHub username" });
+  const searchButton = page.getByRole("button", { name: "Search", exact: true });
+  const clearButton = page.getByRole("button", { name: "Clear recent searches" });
+  const recentSearchButton = page.getByRole("button", { name: "Search octocat again" });
+
+  await expect(searchBox).toBeFocused();
+
+  await searchBox.pressSequentially("octocat");
+  await page.keyboard.press("Tab");
+  await expect(searchButton).toBeFocused();
+
+  await page.keyboard.press("Tab");
+  await expect(clearButton).toBeFocused();
+
+  await page.keyboard.press("Tab");
+  await expect(recentSearchButton).toBeFocused();
 });
 
 test("home page keeps the search form compact when helper text is visible", async ({ page }) => {


### PR DESCRIPTION
## Summary
Add a focused accessibility polish pass for homepage landmarks, keyboard flow, and operational docs.

## Changes
- Add accessible names for the site header, main search content, and footer landmarks.
- Add Playwright coverage for landmarks, privacy content, and keyboard tab order through search/recent-search actions.
- Document the accessibility checks in the production runbook.
- Update the changelog.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm run lint
  - npm test -- --run app/page.test.tsx
  - npm run test:e2e -- tests/e2e/home.spec.ts
  - npm test
  - npm run build

## Screenshots (if applicable)
N/A

## Related Issues
N/A