### PR TITLE
docs(project): add roadmap and label guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Added
 
+- Roadmap and label guidance for lightweight project planning.
+
+## 0.1.0 - 2026-05-11
+
+### Added
+
 - Architecture note and manual QA checklist with Open Graph preview validation steps.
 - Accessibility checks for landmarks, keyboard tab order, and privacy content.
 - Baseline security headers for app, API, 404, and generated image responses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Thanks for helping improve My First Commit. Keep changes small, tested, and easy
 - Use Conventional Commit style for titles, for example `feat(app): add runtime health endpoint`.
 - Include what changed, why it changed, and how it was tested.
 - Do not include secrets, debug statements, or unrelated formatting churn.
+- Use the [label guide](docs/labels.md) to keep issue and pull request labels consistent.
 
 ## Dependency Updates
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The app is intentionally small: no accounts, no database, and no server-side sto
 - **Architecture:** [docs/architecture.md](docs/architecture.md)
 - **Manual QA checklist:** [docs/manual-qa.md](docs/manual-qa.md)
 - **Contributing guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Roadmap:** [ROADMAP.md](ROADMAP.md)
 - **Changelog:** [CHANGELOG.md](CHANGELOG.md)
 
 ## How It Works
@@ -70,6 +71,7 @@ The app is a Next.js App Router project. The browser collects a GitHub username,
 - Use the [architecture note](docs/architecture.md) to understand the browser, server action, GitHub API, and UI flow.
 - Use the [manual QA checklist](docs/manual-qa.md) for release and Open Graph preview validation.
 - Use the [contributing guide](CONTRIBUTING.md) for branch, PR, review, and validation workflow.
+- Use the [roadmap](ROADMAP.md) to track near-term and deferred ideas.
 - Use the [changelog](CHANGELOG.md) to track user-facing changes and release notes.
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,22 @@
+# Roadmap
+
+This roadmap is intentionally lightweight. It captures useful next ideas without turning a small personal app into a process machine.
+
+## Now
+
+- Keep dependency PRs current and merge safe patch/minor updates after CI passes.
+- Keep the changelog updated when behavior, docs, operations, dependencies, or security posture changes.
+- Use the manual QA checklist for larger UI, metadata, and release-verification changes.
+
+## Later
+
+- Add a tuned `Content-Security-Policy-Report-Only` header.
+- Observe CSP behavior in Vercel preview and production before enforcing it.
+- Tighten the CSP gradually once Next.js runtime behavior and Vercel Analytics are confirmed.
+- Add label sync automation if manual label management becomes annoying.
+
+## Maybe
+
+- Add a small public examples section with interesting first-commit searches.
+- Add optional share-card copy for discovered commits.
+- Add a small visual refresh if the app grows beyond a personal utility.

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,27 @@
+# Labels
+
+Use labels to make issues and pull requests easy to scan. Keep the set small.
+
+## Suggested Labels
+
+- `bug`: Something is broken or behaving unexpectedly.
+- `feature`: A new user-facing capability.
+- `maintenance`: Cleanup, refactors, chores, or upkeep that does not change user behavior.
+- `dependencies`: Dependency updates, lockfile changes, or package maintenance.
+- `security`: Security hardening, vulnerabilities, tokens, headers, or dependency advisories.
+- `production`: Deployment, health checks, monitoring, Vercel, or production incidents.
+- `docs`: README, runbook, changelog, contributing, architecture, or QA documentation.
+- `accessibility`: Keyboard, focus, landmarks, announcements, or screen-reader improvements.
+- `testing`: Unit, e2e, CI, smoke, or QA coverage.
+
+## Usage Notes
+
+- Prefer one or two labels per issue or PR.
+- Use `production` with `bug` for live-site regressions.
+- Use `security` with `dependencies` for Dependabot security updates.
+- Use `maintenance` for small ownership improvements that are not visible to users.
+- Use `docs` for documentation-only changes.
+
+## Future Automation
+
+If manual label management becomes tedious, add a label sync workflow or `.github/labels.yml` in a separate PR.


### PR DESCRIPTION
## Summary
Add lightweight planning and issue hygiene docs, and cut the current changelog into a first baseline release.

## Changes
- Add ROADMAP.md with Now/Later/Maybe sections and CSP listed as a deferred item.
- Add docs/labels.md with a small suggested label set and usage notes.
- Move the current changelog baseline into 0.1.0 dated 2026-05-11 and leave new roadmap/label work under Unreleased.
- Link the roadmap from README and the label guide from CONTRIBUTING.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing steps:
  - git diff --check
  - rg -n "Roadmap|Labels|label guide|0.1.0|2026-05-11|Content-Security-Policy-Report-Only" README.md CONTRIBUTING.md CHANGELOG.md ROADMAP.md docs/labels.md

## Screenshots (if applicable)
N/A

## Related Issues
N/A