### PR TITLE
docs(repo): polish issue and dependency hygiene

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,3 +42,14 @@ body:
     attributes:
       label: Extra context
       description: Add browser, device, URL, screenshots, or logs if useful.
+  - type: checkboxes
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - label: This affects production.
+          required: false
+        - label: This affects accessibility, keyboard flow, or screen-reader behavior.
+          required: false
+        - label: This may involve security, privacy, or token handling.
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature request
 description: Suggest a small product improvement.
 title: "feat: "
 labels:
-  - enhancement
+  - feature
 body:
   - type: textarea
     id: problem
@@ -33,3 +33,5 @@ body:
           required: false
         - label: This needs new tests.
           required: true
+        - label: This needs docs or manual QA updates.
+          required: false

--- a/.github/ISSUE_TEMPLATE/maintenance_task.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance_task.yml
@@ -19,7 +19,7 @@ body:
       description: How will we know this is done?
       placeholder: |
         - CI passes
-        - Deployed smoke passes
+        - Production Health Check passes, if production behavior changes
         - Runbook is updated if needed
     validations:
       required: true
@@ -32,3 +32,5 @@ body:
           required: true
         - label: Tests or documentation are updated when behavior changes.
           required: true
+        - label: Labels match the label guide when this creates or updates issues.
+          required: false

--- a/.github/ISSUE_TEMPLATE/maintenance_task.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance_task.yml
@@ -19,7 +19,7 @@ body:
       description: How will we know this is done?
       placeholder: |
         - CI passes
-        - Production Health Check passes, if production behavior changes
+        - Production Health Check passes if production behavior changes
         - Runbook is updated if needed
     validations:
       required: true

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,35 @@
+- name: bug
+  color: d73a4a
+  description: Something is broken or behaving unexpectedly.
+
+- name: feature
+  color: 0e8a16
+  description: A new user-facing capability.
+
+- name: maintenance
+  color: cfd3d7
+  description: Cleanup, refactors, chores, or upkeep that does not change user behavior.
+
+- name: dependencies
+  color: 0366d6
+  description: Dependency updates, lockfile changes, or package maintenance.
+
+- name: security
+  color: b60205
+  description: Security hardening, vulnerabilities, tokens, headers, or dependency advisories.
+
+- name: production
+  color: fbca04
+  description: Deployment, health checks, monitoring, Vercel, or production incidents.
+
+- name: docs
+  color: 0075ca
+  description: README, runbook, changelog, contributing, architecture, or QA documentation.
+
+- name: accessibility
+  color: 5319e7
+  description: Keyboard, focus, landmarks, announcements, or screen-reader improvements.
+
+- name: testing
+  color: 1d76db
+  description: Unit, e2e, CI, production health, or QA coverage.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run browser smoke tests
+      - name: Run browser health checks
         run: npm run test:e2e
 
       - name: Lint

--- a/.github/workflows/deployed-smoke.yml
+++ b/.github/workflows/deployed-smoke.yml
@@ -13,7 +13,7 @@ permissions:
   issues: write
 
 jobs:
-  smoke:
+  production-health-check:
     name: Playwright production health check
     if: >-
       github.event_name == 'workflow_dispatch' ||

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Added
 
+- Label sync configuration, issue template polish, and dependency update policy.
 - Roadmap and label guidance for lightweight project planning.
 
 ## 0.1.0 - 2026-05-11

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ Thanks for helping improve My First Commit. Keep changes small, tested, and easy
 
 Dependabot opens dependency PRs. Review and merge them one at a time when possible, after CI passes.
 
+Major upgrades are handled manually as planned maintenance. Use the [development guide](docs/development.md#dependency-update-policy) before upgrading major versions.
+
 ## Production Checks
 
 After a PR merges to `main`, Vercel deploys production and GitHub Actions runs the production health check against the public app URL.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The app is intentionally small: no accounts, no database, and no server-side sto
 - **Contributing guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
 - **Roadmap:** [ROADMAP.md](ROADMAP.md)
 - **Changelog:** [CHANGELOG.md](CHANGELOG.md)
+- **Label guide:** [docs/labels.md](docs/labels.md)
 
 ## How It Works
 
@@ -72,6 +73,7 @@ The app is a Next.js App Router project. The browser collects a GitHub username,
 - Use the [manual QA checklist](docs/manual-qa.md) for release and Open Graph preview validation.
 - Use the [contributing guide](CONTRIBUTING.md) for branch, PR, review, and validation workflow.
 - Use the [roadmap](ROADMAP.md) to track near-term and deferred ideas.
+- Use the [label guide](docs/labels.md) for issue and pull request labels.
 - Use the [changelog](CHANGELOG.md) to track user-facing changes and release notes.
 
 ## License

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,3 +111,22 @@ See the [production runbook](production.md) for deployment checks, observability
 - Keep PRs focused and wait for CI, Vercel preview, and Copilot review.
 - Use the issue templates for bugs, feature ideas, and maintenance tasks.
 - Merge dependency updates one at a time when possible.
+
+## Dependency Update Policy
+
+Dependabot opens weekly patch and minor updates for npm packages and GitHub Actions. Major npm version updates are intentionally ignored by Dependabot because they often need compatibility review.
+
+For dependency pull requests:
+
+1. Merge one dependency PR at a time when possible.
+2. Confirm CI and Vercel preview are green.
+3. Review `package-lock.json` for unrelated churn.
+4. Check release notes for packages that touch Next.js, React, Octokit, Playwright, or Vercel.
+
+For major upgrades:
+
+1. Open a dedicated maintenance issue or PR.
+2. Read the migration guide or release notes first.
+3. Upgrade the package and lockfile together.
+4. Run `npm test`, `npm run lint`, `npm run build`, and `npm run test:e2e`.
+5. Update docs, runbook notes, or the changelog when behavior, commands, Node requirements, or deployment assumptions change.

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -12,7 +12,7 @@ Use labels to make issues and pull requests easy to scan. Keep the set small.
 - `production`: Deployment, health checks, monitoring, Vercel, or production incidents.
 - `docs`: README, runbook, changelog, contributing, architecture, or QA documentation.
 - `accessibility`: Keyboard, focus, landmarks, announcements, or screen-reader improvements.
-- `testing`: Unit, e2e, CI, smoke, or QA coverage.
+- `testing`: Unit, e2e, CI, production health, or QA coverage.
 
 ## Usage Notes
 
@@ -24,4 +24,20 @@ Use labels to make issues and pull requests easy to scan. Keep the set small.
 
 ## Future Automation
 
-If manual label management becomes tedious, add a label sync workflow or `.github/labels.yml` in a separate PR.
+The canonical label set is captured in `.github/labels.yml`.
+
+To sync labels manually with GitHub CLI:
+
+```bash
+gh label create bug --color d73a4a --description "Something is broken or behaving unexpectedly."
+gh label create feature --color 0e8a16 --description "A new user-facing capability."
+gh label create maintenance --color cfd3d7 --description "Cleanup, refactors, chores, or upkeep that does not change user behavior."
+gh label create dependencies --color 0366d6 --description "Dependency updates, lockfile changes, or package maintenance."
+gh label create security --color b60205 --description "Security hardening, vulnerabilities, tokens, headers, or dependency advisories."
+gh label create production --color fbca04 --description "Deployment, health checks, monitoring, Vercel, or production incidents."
+gh label create docs --color 0075ca --description "README, runbook, changelog, contributing, architecture, or QA documentation."
+gh label create accessibility --color 5319e7 --description "Keyboard, focus, landmarks, announcements, or screen-reader improvements."
+gh label create testing --color 1d76db --description "Unit, e2e, CI, production health, or QA coverage."
+```
+
+Use `gh label edit <name>` instead of `create` when a label already exists. Add automated label syncing later only if manual sync becomes annoying.

--- a/docs/production.md
+++ b/docs/production.md
@@ -101,7 +101,7 @@ Run a health check against production:
 npm run test:e2e:deployed
 ```
 
-The deployed browser health check covers the home page, branded 404 page, generated social assets, and `/api/health`.
+The Production Health Check browser workflow covers the home page, branded 404 page, generated social assets, and `/api/health`.
 
 Check the runtime health endpoint directly:
 


### PR DESCRIPTION
## Summary
Add repo hygiene guidance for labels, issue templates, dependency updates, and production health naming.

## Changes
- Add canonical .github/labels.yml and manual label sync guidance.
- Align issue templates with the label guide and production/accessibility/security impact prompts.
- Document dependency update policy, including manual handling for major upgrades.
- Tune production health check wording and workflow/CI step names away from old smoke-test wording.
- Link label guidance from README and CONTRIBUTING.
- Update changelog.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing steps:
  - git diff --check
  - rg -n "deployed smoke|Deployed Smoke|smoke" .github README.md docs CONTRIBUTING.md CHANGELOG.md ROADMAP.md package.json

## Screenshots (if applicable)
N/A

## Related Issues
N/A