### PR TITLE
feat(app): add production polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Production runbook
+    url: https://github.com/scottdensmore/my-first-commit/blob/main/docs/production.md
+    about: Use this when the live app, Vercel deployment, or production health check needs attention.
+  - name: Security guidance
+    url: https://github.com/scottdensmore/my-first-commit/blob/main/docs/development.md#environment-variables
+    about: Review token and environment-variable guidance before reporting sensitive configuration issues.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -33,3 +33,11 @@
 - name: testing
   color: 1d76db
   description: Unit, e2e, CI, production health, or QA coverage.
+
+- name: release
+  color: 0052cc
+  description: Tags, changelog entries, release notes, or GitHub releases.
+
+- name: privacy
+  color: 6f42c1
+  description: Search data handling, analytics boundaries, or local browser storage.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing semantic version tag to publish, for example v0.1.0.
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish-release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: release
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            tag="$INPUT_TAG"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+
+          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Release tag must match vX.Y.Z."
+            exit 1
+          fi
+
+          if ! git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag does not exist."
+            exit 1
+          fi
+
+          version="${tag#v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog notes
+        id: notes
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          awk -v version="$VERSION" '
+            $0 ~ "^## " version "($| )" {
+              capture = 1
+              next
+            }
+            capture && /^## / {
+              exit
+            }
+            capture {
+              print
+            }
+          ' CHANGELOG.md > release-notes.md
+
+          if [ ! -s release-notes.md ]; then
+            echo "No CHANGELOG.md section found for $VERSION."
+            echo "Add a '## $VERSION' section before publishing."
+            exit 1
+          fi
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: gh release create "$TAG" --title "$TAG" --notes-file release-notes.md --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Added
 
+- Privacy page, example searches, privacy-safe analytics events, issue chooser config, and release publishing workflow.
 - Release guide, expanded known limitations, and local Playwright coverage for result and error states.
 - Result sharing, source repository context, and richer first-commit metadata.
 - Label sync configuration, issue template polish, and dependency update policy.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The app is intentionally small: no accounts, no database, and no server-side sto
 - **Origin Discovery:** Uses the GitHub Search API to find the earliest public commits for any user.
 - **Visual Timeline:** Displays a sequence of the first 10 commits, connected by a vertical line with GitHub-style contribution squares.
 - **Recent Searches:** Keeps successful searches as local browser shortcuts for quick reruns.
+- **Example Searches:** Offers known public GitHub profiles as quick checks for first-time use and empty-result recovery.
 - **Shareable Searches:** Updates the URL with the searched username so results can be shared.
 - **GitHub Aesthetic:** Fully themed with GitHub's color palette, typography, and iconography.
 - **Responsive Design:** Optimized for both desktop and mobile viewing.
@@ -57,6 +58,7 @@ The app is a Next.js App Router project. The browser collects a GitHub username,
 - Usernames entered into the search field are sent to GitHub to retrieve public commit data.
 - `GITHUB_TOKEN` is used only server-side and is never exposed to the browser.
 - Recent searches are stored only in the user's browser under `my-first-commit:recent-searches`.
+- Vercel Analytics records page views and privacy-safe product events; analytics events do not include searched usernames.
 - The app does not store searches on a server.
 
 ## Limitations

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -2,13 +2,19 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Home from "./page";
 import { getCommits } from "./actions";
+import { track } from "@vercel/analytics";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./actions", () => ({
   getCommits: vi.fn(),
 }));
 
+vi.mock("@vercel/analytics", () => ({
+  track: vi.fn(),
+}));
+
 const mockGetCommits = vi.mocked(getCommits);
+const mockTrack = vi.mocked(track);
 
 const commitResult = {
   found: true,
@@ -35,6 +41,7 @@ const commitResult = {
 describe("Home", () => {
   beforeEach(() => {
     mockGetCommits.mockReset();
+    mockTrack.mockReset();
     window.localStorage.clear();
     window.history.replaceState(null, "", "/");
   });
@@ -74,6 +81,15 @@ describe("Home", () => {
     expect(screen.getByText(/earliest indexed public commit for @octo appears in/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "octo/repo" })).toHaveAttribute("href", "https://github.com/octo/repo");
     expect(await screen.findByRole("link", { name: "Initial commit" })).toBeInTheDocument();
+    expect(mockTrack).toHaveBeenCalledWith("search_submitted", {
+      source: "user",
+    });
+    expect(mockTrack).toHaveBeenCalledWith("search_completed", {
+      found: true,
+      error_kind: "none",
+      commit_count: 1,
+    });
+    expect(mockTrack.mock.calls.flatMap((call) => Object.values(call[1] ?? {}))).not.toContain("octo");
   });
 
   it("copies a shareable result summary", async () => {
@@ -92,6 +108,7 @@ describe("Home", () => {
     });
     await expect(navigator.clipboard.readText()).resolves.toContain("octo's first public commit: Initial commit");
     await expect(navigator.clipboard.readText()).resolves.toContain("https://github.com/octo/repo/commit/abcdef123456");
+    expect(mockTrack).toHaveBeenCalledWith("result_copied", undefined);
   });
 
   it("shows a helpful status when copying a result fails", async () => {
@@ -110,6 +127,7 @@ describe("Home", () => {
       expect(screen.getByRole("status")).toHaveTextContent(/could not copy result/i);
     });
     expect(writeText).toHaveBeenCalled();
+    expect(mockTrack).toHaveBeenCalledWith("result_copy_failed", undefined);
   });
 
   it("renders same-SHA commits from different repositories without key collisions", async () => {
@@ -159,6 +177,9 @@ describe("Home", () => {
       expect(mockGetCommits).toHaveBeenCalledWith("octo");
     });
     expect(await screen.findByRole("link", { name: "Initial commit" })).toBeInTheDocument();
+    expect(mockTrack).toHaveBeenCalledWith("search_submitted", {
+      source: "shared_url",
+    });
   });
 
   it("does not auto-search an invalid username from the URL", () => {
@@ -239,6 +260,21 @@ describe("Home", () => {
 
     expect(screen.queryByRole("heading", { name: /recent searches/i })).not.toBeInTheDocument();
     expect(window.localStorage.getItem("my-first-commit:recent-searches")).toBeNull();
+  });
+
+  it("renders example searches before any result is shown", async () => {
+    mockGetCommits.mockResolvedValue(commitResult);
+    const user = userEvent.setup();
+    render(<Home />);
+
+    expect(screen.getByRole("heading", { name: /examples/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /search example username octocat/i }));
+
+    await waitFor(() => {
+      expect(mockGetCommits).toHaveBeenCalledWith("octocat");
+    });
+    expect(window.location.search).toBe("?user=octocat");
   });
 
   it("does not save failed searches as recent local shortcuts", async () => {
@@ -393,6 +429,8 @@ describe("Home", () => {
     expect(await screen.findByRole("heading", { name: /no public commits found/i })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent(/no public commits found/i);
     expect(screen.getByText(/try another username or check back later/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /check a known public profile/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /search example username octocat/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /edit username/i })).toBeInTheDocument();
   });
 
@@ -539,6 +577,7 @@ describe("Home", () => {
     expect(screen.queryByText(/MyFirstCommit Clone/i)).not.toBeInTheDocument();
     expect(screen.getByText(/recent searches stay in this browser only/i)).toBeInTheDocument();
     expect(screen.getByText(/not stored on this app's server/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /read the privacy note/i })).toHaveAttribute("href", "/privacy");
     expect(screen.getByText(/Not affiliated with GitHub/i)).toBeInTheDocument();
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,21 @@
 import React, { useCallback, useEffect, useRef, useState, useTransition } from 'react';
 import { getCommits, CommitData } from './actions';
 import FirstCommitDisplay from '@/components/FirstCommitDisplay';
+import { track } from "@vercel/analytics";
 import { FaGithub } from "react-icons/fa";
 import { GoCopy } from "react-icons/go";
 
 const RECENT_SEARCHES_STORAGE_KEY = "my-first-commit:recent-searches";
 const MAX_RECENT_SEARCHES = 5;
+const EXAMPLE_USERNAMES = ["octocat", "torvalds", "gaearon"];
+
+function trackAppEvent(name: string, properties?: Record<string, string | number | boolean>) {
+  try {
+    track(name, properties);
+  } catch {
+    // Analytics should never interrupt the search experience.
+  }
+}
 
 function getUsernameValidationMessage(value: string) {
   const username = value.trim();
@@ -173,11 +183,19 @@ export default function Home() {
     if (getUsernameValidationMessage(trimmedUsername)) return;
     if (options.updateUrl) updateSharedSearchUrl(trimmedUsername);
 
+    trackAppEvent("search_submitted", {
+      source: options.updateUrl ? "user" : "shared_url",
+    });
     setLastSearchedUsername(trimmedUsername);
     setShareStatus("");
     startTransition(async () => {
        const data = await getCommits(trimmedUsername);
        setResult(data);
+       trackAppEvent("search_completed", {
+        found: data.found,
+        error_kind: data.errorKind ?? "none",
+        commit_count: data.commits.length,
+       });
        if (data.found) {
         rememberRecentSearch(trimmedUsername);
        }
@@ -227,14 +245,17 @@ export default function Home() {
   const copyResult = async () => {
     if (!result?.found || !navigator.clipboard) {
       setShareStatus("Copy is not available in this browser.");
+      trackAppEvent("result_copy_unavailable");
       return;
     }
 
     try {
       await navigator.clipboard.writeText(buildResultShareText(lastSearchedUsername, result));
       setShareStatus("Result copied.");
+      trackAppEvent("result_copied");
     } catch {
       setShareStatus("Could not copy result. Use the commit link instead.");
+      trackAppEvent("result_copy_failed");
     }
   };
 
@@ -358,6 +379,30 @@ export default function Home() {
             </section>
         )}
 
+        {!result && (
+            <section aria-labelledby="examples-heading" className="mt-6 w-full max-w-md">
+                <h2 id="examples-heading" className="text-xs font-semibold uppercase tracking-normal text-[var(--github-gray-text)]">
+                    Examples
+                </h2>
+                <div className="mt-2 flex flex-wrap gap-2">
+                    {EXAMPLE_USERNAMES.map((exampleUsername) => (
+                        <button
+                            key={exampleUsername}
+                            type="button"
+                            onClick={() => {
+                                setUsername(exampleUsername);
+                                searchCommits(exampleUsername, { updateUrl: true });
+                            }}
+                            className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+                            aria-label={`Search example username ${exampleUsername}`}
+                        >
+                            @{exampleUsername}
+                        </button>
+                    ))}
+                </div>
+            </section>
+        )}
+
         {isPending && !result && (
             <div role="status" aria-live="polite" className="mt-5 w-full max-w-md rounded-md border border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-3 text-sm text-[var(--github-gray-text)]">
                 Searching GitHub for {lastSearchedUsername}...
@@ -373,6 +418,29 @@ export default function Home() {
                 <p className="mt-2 text-sm text-[var(--github-gray-text)]">
                     {resultMessage?.description}
                 </p>
+                {isEmptyResult && (
+                    <div className="mt-4 rounded-md border border-[var(--github-border)] bg-white p-3">
+                        <h3 className="text-sm font-semibold text-[var(--github-gray-dark)]">
+                            Check a known public profile
+                        </h3>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                            {EXAMPLE_USERNAMES.map((exampleUsername) => (
+                                <button
+                                    key={exampleUsername}
+                                    type="button"
+                                    onClick={() => {
+                                        setUsername(exampleUsername);
+                                        searchCommits(exampleUsername, { updateUrl: true });
+                                    }}
+                                    className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+                                    aria-label={`Search example username ${exampleUsername}`}
+                                >
+                                    @{exampleUsername}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                )}
                 <div className="mt-4 flex flex-wrap gap-2">
                     {canRetrySearch && (
                         <button
@@ -467,7 +535,11 @@ export default function Home() {
       {/* Footer */}
       <footer aria-label="Privacy and GitHub affiliation" className="border-t border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-6 text-center text-xs text-[var(--github-gray-text)]">
         <p className="mx-auto mb-2 max-w-2xl">
-            Privacy: searches are sent to GitHub to find public commits. Recent searches stay in this browser only and are not stored on this app&apos;s server.
+            Privacy: searches are sent to GitHub to find public commits. Recent searches stay in this browser only and are not stored on this app&apos;s server.{" "}
+            <a href="/privacy" className="font-semibold text-[var(--github-blue)] hover:underline">
+                Read the privacy note
+            </a>
+            .
         </p>
         <p>&copy; {new Date().getFullYear()} Not affiliated with GitHub.</p>
       </footer>

--- a/app/privacy/page.test.tsx
+++ b/app/privacy/page.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import PrivacyPage, { metadata } from "./page";
+
+describe("PrivacyPage", () => {
+  it("documents search, local storage, analytics, and token handling", () => {
+    render(<PrivacyPage />);
+
+    expect(screen.getByRole("heading", { name: "Privacy" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to search/i })).toHaveAttribute("href", "/");
+    expect(screen.getByText(/sent to GitHub/i)).toBeInTheDocument();
+    expect(screen.getByText(/my-first-commit:recent-searches/i)).toBeInTheDocument();
+    expect(screen.getByText(/analytics events do not include the searched GitHub username/i)).toBeInTheDocument();
+    expect(screen.getByText(/never sent to the browser/i)).toBeInTheDocument();
+  });
+
+  it("defines privacy metadata", () => {
+    expect(metadata).toMatchObject({
+      title: "Privacy",
+      description: "How My First Commit handles GitHub usernames, local recent searches, analytics, and server-side tokens.",
+      alternates: {
+        canonical: "/privacy",
+      },
+    });
+  });
+});

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy",
+  description: "How My First Commit handles GitHub usernames, local recent searches, analytics, and server-side tokens.",
+  alternates: {
+    canonical: "/privacy",
+  },
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-[var(--background)] px-4 py-12 text-[var(--github-gray-dark)]">
+      <article className="mx-auto max-w-3xl">
+        <Link href="/" className="text-sm font-semibold text-[var(--github-blue)] hover:underline">
+          Back to search
+        </Link>
+        <h1 className="mt-6 text-3xl font-bold">Privacy</h1>
+        <p className="mt-4 text-base leading-7 text-[var(--github-gray-text)]">
+          My First Commit is a small public GitHub search tool. It does not use accounts, a database, or app-owned server-side search history.
+        </p>
+
+        <section className="mt-8">
+          <h2 className="text-xl font-semibold">Searches</h2>
+          <p className="mt-3 leading-7 text-[var(--github-gray-text)]">
+            Usernames entered into the search form are sent to GitHub so the app can look up public commit data. The app only returns public information that GitHub makes available through its search API.
+          </p>
+        </section>
+
+        <section className="mt-8">
+          <h2 className="text-xl font-semibold">Recent Searches</h2>
+          <p className="mt-3 leading-7 text-[var(--github-gray-text)]">
+            Successful searches can appear as recent-search shortcuts. Those shortcuts are stored only in this browser using local storage under <code className="font-mono text-sm">my-first-commit:recent-searches</code>.
+          </p>
+        </section>
+
+        <section className="mt-8">
+          <h2 className="text-xl font-semibold">Analytics</h2>
+          <p className="mt-3 leading-7 text-[var(--github-gray-text)]">
+            The app uses Vercel Analytics for basic product health signals, such as page views, search completions, result counts, and error categories. Analytics events do not include the searched GitHub username.
+          </p>
+        </section>
+
+        <section className="mt-8">
+          <h2 className="text-xl font-semibold">GitHub Token</h2>
+          <p className="mt-3 leading-7 text-[var(--github-gray-text)]">
+            If configured, <code className="font-mono text-sm">GITHUB_TOKEN</code> is used only on the server to improve GitHub API reliability. It is never sent to the browser and does not allow private commits to be searched.
+          </p>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -13,6 +13,8 @@ Use labels to make issues and pull requests easy to scan. Keep the set small.
 - `docs`: README, runbook, changelog, contributing, architecture, or QA documentation.
 - `accessibility`: Keyboard, focus, landmarks, announcements, or screen-reader improvements.
 - `testing`: Unit, e2e, CI, production health, or QA coverage.
+- `release`: Tags, changelog entries, release notes, or GitHub releases.
+- `privacy`: Search data handling, analytics boundaries, or local browser storage.
 
 ## Usage Notes
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -26,9 +26,16 @@ Use this checklist when cutting a new My First Commit release.
    git push origin vX.Y.Z
    ```
 
-2. Create a GitHub release from the tag.
-3. Use the matching `CHANGELOG.md` section as the release notes.
-4. Mark prereleases only when the release is not intended for normal production use.
+2. Confirm the `Release` workflow publishes the GitHub release automatically.
+3. If needed, run the workflow manually with the existing `vX.Y.Z` tag.
+4. Use the matching `CHANGELOG.md` section as the release notes.
+5. Mark prereleases only when the release is not intended for normal production use.
+
+The release workflow requires a `CHANGELOG.md` section named for the tag without the `v` prefix, for example:
+
+```markdown
+## 0.2.0
+```
 
 ## After Release
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -41,6 +41,8 @@ test("home page search field is keyboard-ready and not treated as a credential f
 
   const searchButton = page.getByRole("button", { name: "Search", exact: true });
   await expect(searchButton).toBeDisabled();
+  await expect(page.getByRole("heading", { name: "Examples" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Search example username octocat" })).toBeVisible();
 
   await searchBox.pressSequentially("octocat");
   await expect(searchBox).toHaveValue("octocat");
@@ -60,6 +62,17 @@ test("home page exposes accessible landmarks and privacy content", async ({ page
   await expect(page.getByRole("search", { name: "GitHub commit search" })).toBeVisible();
   await expect(page.getByRole("contentinfo", { name: "Privacy and GitHub affiliation" })).toBeVisible();
   await expect(page.getByText(/recent searches stay in this browser only/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Read the privacy note" })).toHaveAttribute("href", "/privacy");
+});
+
+test("privacy page documents search and analytics handling", async ({ page }) => {
+  await page.goto("/privacy");
+
+  await expect(page.getByRole("heading", { name: "Privacy" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Back to search" })).toHaveAttribute("href", "/");
+  await expect(page.getByText(/usernames entered into the search form are sent to GitHub/i)).toBeVisible();
+  await expect(page.getByText(/analytics events do not include the searched GitHub username/i)).toBeVisible();
+  await expect(page.getByText(/never sent to the browser/i)).toBeVisible();
 });
 
 test("home page tab order keeps primary actions reachable", async ({ page }) => {
@@ -96,7 +109,7 @@ test("home page keeps the search form compact when helper text is visible", asyn
   await page.goto("/");
 
   const searchBox = page.getByRole("searchbox", { name: "GitHub username" });
-  const searchButton = page.getByRole("button", { name: "Search" });
+  const searchButton = page.getByRole("button", { name: "Search", exact: true });
 
   await page.waitForLoadState("networkidle");
   await expect(searchBox).toBeVisible();
@@ -139,7 +152,7 @@ test("home page blocks invalid usernames without leaving keyboard flow", async (
   await page.goto("/");
 
   const searchBox = page.getByRole("searchbox", { name: "GitHub username" });
-  const searchButton = page.getByRole("button", { name: "Search" });
+  const searchButton = page.getByRole("button", { name: "Search", exact: true });
 
   await searchBox.fill("octo_cat");
 
@@ -260,6 +273,8 @@ test.describe("local mocked commit search states", () => {
     await expect(page.getByRole("heading", { name: "No public commits found." })).toBeVisible();
     await expect(page.getByRole("status")).toContainText("No public commits found.");
     await expect(page.getByText(/GitHub commit search indexing can lag/i)).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Check a known public profile" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Search example username octocat" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Edit username" })).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
Adds the next production-readiness pass: privacy-safe analytics events, a privacy page, example searches, friendlier empty-state recovery, issue-template chooser config, release labels, and a tag-driven release workflow.

## Changes
- Track search/copy events through Vercel Analytics without sending searched usernames
- Add example username buttons before search and in empty-result recovery
- Add a dedicated privacy page and footer link
- Add issue template config and release/privacy labels
- Add a Release workflow that publishes GitHub releases from semantic version tags using CHANGELOG notes
- Update README, label docs, release guide, changelog, unit tests, and E2E coverage

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm audit
  - npm run lint
  - npm test
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
N/A

## Related Issues
Closes #