### PR TITLE
ci(release): promote healthy deployments

### DIFF
--- a/.github/workflows/promote-production-release.yml
+++ b/.github/workflows/promote-production-release.yml
@@ -1,0 +1,70 @@
+name: Promote Production Release
+
+on:
+  workflow_run:
+    workflows:
+      - Production Health Check
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    name: Tag and release healthy production deployment
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'deployment_status' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out deployed commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Resolve release tag
+        id: release
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          short_sha="$(printf '%s' "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)"
+          tag="v${version}-${short_sha}"
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists."
+          else
+            git tag "$TAG" "$TARGET_SHA"
+            git push origin "$TAG"
+          fi
+
+          {
+            echo "Production deployment release for $TAG."
+            echo
+            echo "This release was created automatically after Vercel deployed the commit and the Production Health Check passed."
+            echo
+            echo "- Commit: $TARGET_SHA"
+            echo "- Production health check: $RUN_URL"
+          } > release-notes.md
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            --target "$TARGET_SHA" \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing semantic version tag to publish, for example v0.1.0.
+        description: Existing release tag to publish, for example v0.1.0 or v0.1.0-abcdef1.
         required: true
 
 permissions:
@@ -35,8 +35,8 @@ jobs:
             tag="${GITHUB_REF_NAME}"
           fi
 
-          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Release tag must match vX.Y.Z."
+          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9a-f]{7,40})?$'; then
+            echo "Release tag must match vX.Y.Z or vX.Y.Z-<commit-sha>."
             exit 1
           fi
 
@@ -46,16 +46,20 @@ jobs:
           fi
 
           version="${tag#v}"
+          base_version="${version%%-*}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "base_version=$base_version" >> "$GITHUB_OUTPUT"
 
       - name: Extract changelog notes
         id: notes
         env:
           VERSION: ${{ steps.release.outputs.version }}
+          BASE_VERSION: ${{ steps.release.outputs.base_version }}
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
-          awk -v version="$VERSION" '
-            $0 ~ "^## " version "($| )" {
+          awk -v version="$VERSION" -v base_version="$BASE_VERSION" '
+            $0 ~ "^## " version "($| )" || $0 ~ "^## " base_version "($| )" {
               capture = 1
               next
             }
@@ -67,7 +71,15 @@ jobs:
             }
           ' CHANGELOG.md > release-notes.md
 
-          if [ ! -s release-notes.md ]; then
+          if [ ! -s release-notes.md ] && printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}$'; then
+            {
+              echo "Production deployment release for $TAG."
+              echo
+              echo "This release was created automatically after Vercel deployed the commit and the Production Health Check passed."
+              echo
+              echo "See the commit history for the exact changes included in this deployment."
+            } > release-notes.md
+          elif [ ! -s release-notes.md ]; then
             echo "No CHANGELOG.md section found for $VERSION."
             echo "Add a '## $VERSION' section before publishing."
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Added
 
+- Automatic production release promotion and footer release links for deployed versions.
 - Privacy page, example searches, privacy-safe analytics events, issue chooser config, and release publishing workflow.
 - Release guide, expanded known limitations, and local Playwright coverage for result and error states.
 - Result sharing, source repository context, and richer first-commit metadata.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The app is intentionally small: no accounts, no database, and no server-side sto
 - **Recent Searches:** Keeps successful searches as local browser shortcuts for quick reruns.
 - **Example Searches:** Offers known public GitHub profiles as quick checks for first-time use and empty-result recovery.
 - **Shareable Searches:** Updates the URL with the searched username so results can be shared.
+- **Release Visibility:** Shows the deployed release tag in the footer and links it to the matching GitHub release.
 - **GitHub Aesthetic:** Fully themed with GitHub's color palette, typography, and iconography.
 - **Responsive Design:** Optimized for both desktop and mobile viewing.
 - **Production Checks:** Uses CI, production health checks, Vercel Analytics, and structured server logs.
@@ -52,6 +53,7 @@ The app is a Next.js App Router project. The browser collects a GitHub username,
 - **Icons:** [React Icons](https://react-icons.github.io/react-icons/)
 - **Date Handling:** [date-fns](https://date-fns.org/)
 - **Monitoring:** [Vercel Analytics](https://vercel.com/analytics), Vercel Logs, and GitHub Actions
+- **Releases:** Automatic GitHub releases after healthy Vercel production deployments
 
 ## Privacy
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -579,5 +579,6 @@ describe("Home", () => {
     expect(screen.getByText(/not stored on this app's server/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /read the privacy note/i })).toHaveAttribute("href", "/privacy");
     expect(screen.getByText(/Not affiliated with GitHub/i)).toBeInTheDocument();
+    expect(screen.getByText(/Release v0.1.0-local/i)).toBeInTheDocument();
   });
 });

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -579,6 +579,6 @@ describe("Home", () => {
     expect(screen.getByText(/not stored on this app's server/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /read the privacy note/i })).toHaveAttribute("href", "/privacy");
     expect(screen.getByText(/Not affiliated with GitHub/i)).toBeInTheDocument();
-    expect(screen.getByText(/Release v0.1.0-local/i)).toBeInTheDocument();
+    expect(screen.getByText("Release local")).toBeInTheDocument();
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,8 @@ import { GoCopy } from "react-icons/go";
 const RECENT_SEARCHES_STORAGE_KEY = "my-first-commit:recent-searches";
 const MAX_RECENT_SEARCHES = 5;
 const EXAMPLE_USERNAMES = ["octocat", "torvalds", "gaearon"];
+const APP_RELEASE = process.env.NEXT_PUBLIC_APP_RELEASE ?? "v0.1.0-local";
+const APP_RELEASE_URL = process.env.NEXT_PUBLIC_APP_RELEASE_URL ?? "";
 
 function trackAppEvent(name: string, properties?: Record<string, string | number | boolean>) {
   try {
@@ -541,7 +543,16 @@ export default function Home() {
             </a>
             .
         </p>
-        <p>&copy; {new Date().getFullYear()} Not affiliated with GitHub.</p>
+        <p>
+            &copy; {new Date().getFullYear()} Not affiliated with GitHub.{" "}
+            {APP_RELEASE_URL ? (
+                <a href={APP_RELEASE_URL} className="font-semibold text-[var(--github-blue)] hover:underline">
+                    Release {APP_RELEASE}
+                </a>
+            ) : (
+                <span>Release {APP_RELEASE}</span>
+            )}
+        </p>
       </footer>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ import { GoCopy } from "react-icons/go";
 const RECENT_SEARCHES_STORAGE_KEY = "my-first-commit:recent-searches";
 const MAX_RECENT_SEARCHES = 5;
 const EXAMPLE_USERNAMES = ["octocat", "torvalds", "gaearon"];
-const APP_RELEASE = process.env.NEXT_PUBLIC_APP_RELEASE ?? "v0.1.0-local";
+const APP_RELEASE = process.env.NEXT_PUBLIC_APP_RELEASE ?? "local";
 const APP_RELEASE_URL = process.env.NEXT_PUBLIC_APP_RELEASE_URL ?? "";
 
 function trackAppEvent(name: string, properties?: Record<string, string | number | boolean>) {

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,6 +19,14 @@ Use this checklist when cutting a new My First Commit release.
 
 ## Publish Release
 
+Production releases are created automatically after a merge to `main`, a successful Vercel production deployment, and a passing `Production Health Check`. The `Promote Production Release` workflow creates both the Git tag and the GitHub release. The automatic tag format is:
+
+```text
+vX.Y.Z-<deployed-short-sha>
+```
+
+The deployed footer shows the same release tag and links to the matching GitHub release.
+
 1. Create a tag from the current `main` commit:
 
    ```bash
@@ -36,6 +44,8 @@ The release workflow requires a `CHANGELOG.md` section named for the tag without
 ```markdown
 ## 0.2.0
 ```
+
+Automatic deployment release tags can use generated release notes when a matching changelog section does not exist.
 
 ## After Release
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,20 @@
 import type { NextConfig } from "next";
+import { readFileSync } from "node:fs";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+) as { version: string };
+
+const commitSha = process.env.NEXT_PUBLIC_APP_COMMIT_SHA
+  ?? process.env.VERCEL_GIT_COMMIT_SHA
+  ?? process.env.GITHUB_SHA
+  ?? "";
+const shortCommitSha = commitSha.slice(0, 7);
+const appRelease = process.env.NEXT_PUBLIC_APP_RELEASE
+  ?? (shortCommitSha ? `v${packageJson.version}-${shortCommitSha}` : `v${packageJson.version}-local`);
+const isProductionDeployment = process.env.VERCEL_ENV === "production";
+const appReleaseUrl = process.env.NEXT_PUBLIC_APP_RELEASE_URL
+  ?? (shortCommitSha && isProductionDeployment ? `https://github.com/scottdensmore/my-first-commit/releases/tag/${appRelease}` : "");
 
 const securityHeaders = [
   {
@@ -20,6 +36,10 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_RELEASE: appRelease,
+    NEXT_PUBLIC_APP_RELEASE_URL: appReleaseUrl,
+  },
   async headers() {
     return [
       {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -52,6 +52,7 @@ test("home page search field is keyboard-ready and not treated as a credential f
   await expect(searchButton).toBeFocused();
 
   await expect(page.getByText(/Not affiliated with GitHub/)).toBeVisible();
+  await expect(page.getByText(/Release v0.1.0-/)).toBeVisible();
 });
 
 test("home page exposes accessible landmarks and privacy content", async ({ page }) => {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -52,7 +52,7 @@ test("home page search field is keyboard-ready and not treated as a credential f
   await expect(searchButton).toBeFocused();
 
   await expect(page.getByText(/Not affiliated with GitHub/)).toBeVisible();
-  await expect(page.getByText(/Release v0.1.0-/)).toBeVisible();
+  await expect(page.getByText(/Release v\d+\.\d+\.\d+-/)).toBeVisible();
 });
 
 test("home page exposes accessible landmarks and privacy content", async ({ page }) => {


### PR DESCRIPTION
## Summary
Adds automatic production release promotion after a healthy Vercel deployment. Each successful production deployment gets a deterministic release tag based on the deployed package version and commit SHA, and the app footer shows the same release identifier.

## Changes
- Add a Promote Production Release workflow triggered after the Production Health Check succeeds for a production deployment on main
- Create both the Git tag and GitHub release from the deployed commit in that promotion workflow
- Use release tags like v0.1.0-abcdef1 so the deployed footer can derive the same value at build time
- Expose the app release and production GitHub release URL through Next config
- Show the release identifier in the footer, linking to GitHub releases for production builds
- Update release docs, README, changelog, and tests
- Keep the manual/tag Release workflow compatible with deployment-style tags

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm audit
  - npm run lint
  - npm test
  - npm run build
  - npm run test:e2e
  - ruby YAML parse check for release workflows

## Screenshots (if applicable)
N/A

## Related Issues
Closes #