### PR TITLE
fix(app): harden search and release flow

### DIFF
--- a/.github/workflows/promote-production-release.yml
+++ b/.github/workflows/promote-production-release.yml
@@ -8,7 +8,12 @@ on:
       - completed
 
 permissions:
+  actions: read
   contents: write
+
+concurrency:
+  group: production-release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
 
 jobs:
   promote:
@@ -34,6 +39,21 @@ jobs:
 
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Confirm CI passed for deployed commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          ci_conclusion="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${TARGET_SHA}&branch=main&event=push&status=completed&per_page=10" \
+              --jq '.workflow_runs[0].conclusion // ""'
+          )"
+
+          if [ "$ci_conclusion" != "success" ]; then
+            echo "Expected successful CI run for ${TARGET_SHA}, got '${ci_conclusion:-none}'."
+            exit 1
+          fi
 
       - name: Create tag and GitHub release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Added
 
+- Server-side username validation, sanitized GitHub error logging, short-lived search caching, CSP report-only headers, release workflow hardening, and tighter public health metadata.
 - Automatic production release promotion and footer release links for deployed versions.
 - Privacy page, example searches, privacy-safe analytics events, issue chooser config, and release publishing workflow.
 - Release guide, expanded known limitations, and local Playwright coverage for result and error states.

--- a/app/actions.test.ts
+++ b/app/actions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearCommitSearchCache } from "./commitSearchCache";
 import { getCommits } from "./actions";
 
 const { searchCommits } = vi.hoisted(() => ({
@@ -45,6 +46,7 @@ const commitItem = {
 
 describe("getCommits", () => {
   beforeEach(() => {
+    clearCommitSearchCache();
     searchCommits.mockReset();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
@@ -96,7 +98,7 @@ describe("getCommits", () => {
       commits: [
         {
           message: "Initial commit\n\nAdd project files",
-          date: "2024-01-01T00:00:00Z",
+          date: "2024-01-02T00:00:00Z",
           html_url: "https://github.com/octo/repo/commit/abcdef123456",
           sha: "abcdef123456",
           repository: {
@@ -112,6 +114,43 @@ describe("getCommits", () => {
         },
       ],
     });
+  });
+
+  it("rejects invalid usernames before calling GitHub", async () => {
+    await expect(getCommits("octo_cat")).resolves.toEqual({
+      found: false,
+      error: "Use only letters, numbers, and hyphens.",
+      errorKind: "validation",
+      commits: [],
+    });
+    expect(searchCommits).not.toHaveBeenCalled();
+  });
+
+  it("trims usernames before querying GitHub", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [commitItem],
+      },
+    });
+
+    await getCommits("  octo  ");
+
+    expect(searchCommits).toHaveBeenCalledWith(expect.objectContaining({
+      q: "author:octo",
+    }));
+  });
+
+  it("reuses cached successful search results for the same username", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [commitItem],
+      },
+    });
+
+    await getCommits("Octo");
+    await getCommits("octo");
+
+    expect(searchCommits).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to committer date and ghost author details when GitHub omits author data", async () => {
@@ -240,7 +279,7 @@ describe("getCommits", () => {
       event: "github_commit_search_unavailable",
       status: 503,
       message: "Service Unavailable",
-    }, error);
+    });
   });
 
   it("does not classify non-rate-limit GitHub 403 errors as rate limits", async () => {
@@ -261,7 +300,7 @@ describe("getCommits", () => {
       event: "github_commit_search_failed",
       status: 403,
       message: "Resource not accessible by integration",
-    }, error);
+    });
   });
 
   it("ignores malformed GitHub commit items before deciding whether results exist", async () => {
@@ -322,7 +361,7 @@ describe("getCommits", () => {
       event: "github_commit_search_failed",
       status: 422,
       message: undefined,
-    }, error);
+    });
   });
 
   it("returns a generic message for unknown GitHub errors", async () => {
@@ -339,6 +378,6 @@ describe("getCommits", () => {
       event: "github_commit_search_failed",
       status: undefined,
       message: "GitHub is unavailable",
-    }, error);
+    });
   });
 });

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,7 +1,9 @@
 'use server'
 
 import { Octokit } from "octokit";
+import { getCachedCommitSearch, setCachedCommitSearch } from "./commitSearchCache";
 import { logger } from "./logger";
+import { getUsernameValidationMessage, normalizeGitHubUsername } from "./username";
 
 const octokit = new Octokit({
     auth: process.env.GITHUB_TOKEN 
@@ -214,10 +216,10 @@ function mapCommitItem(item: unknown, username: string): CommitInfo | null {
 
   return {
     message,
-    date: typeof authorDate === "string"
-      ? authorDate
-      : typeof committerDate === "string"
-        ? committerDate
+    date: typeof committerDate === "string"
+      ? committerDate
+      : typeof authorDate === "string"
+        ? authorDate
         : "",
     html_url: htmlUrl,
     sha,
@@ -235,13 +237,24 @@ function mapCommitItem(item: unknown, username: string): CommitInfo | null {
 }
 
 export async function getCommits(username: string): Promise<CommitData> {
-  if (!username) return { found: false, error: "Username is required", errorKind: "validation", commits: [] };
-  const e2eCommitSearchResult = getE2eCommitSearchResult(username);
+  const normalizedUsername = normalizeGitHubUsername(username);
+  if (!normalizedUsername) return { found: false, error: "Username is required", errorKind: "validation", commits: [] };
+
+  const validationMessage = getUsernameValidationMessage(normalizedUsername);
+  if (validationMessage) {
+    return { found: false, error: validationMessage, errorKind: "validation", commits: [] };
+  }
+
+  const e2eCommitSearchResult = getE2eCommitSearchResult(normalizedUsername);
   if (e2eCommitSearchResult) return e2eCommitSearchResult;
+
+  const cacheKey = normalizedUsername.toLowerCase();
+  const cachedCommitSearch = getCachedCommitSearch(cacheKey);
+  if (cachedCommitSearch) return cachedCommitSearch;
 
   try {
     const response = await withTimeoutSignal((signal) => octokit.rest.search.commits({
-      q: `author:${username}`,
+      q: `author:${normalizedUsername}`,
       sort: 'committer-date',
       order: 'asc',
       per_page: 10,
@@ -253,16 +266,18 @@ export async function getCommits(username: string): Promise<CommitData> {
     const items = response.data.items;
 
     if (!items || items.length === 0) {
-      return {
+      const result: CommitData = {
         found: false,
         error: "No public commits found for this user (or indexing is delayed).",
         errorKind: "empty",
         commits: [],
       };
+      setCachedCommitSearch(cacheKey, result);
+      return result;
     }
 
     const commits = items.flatMap((item, itemIndex) => {
-      const commit = mapCommitItem(item, username);
+      const commit = mapCommitItem(item, normalizedUsername);
       if (commit) return [commit];
 
       logger.warn({
@@ -275,18 +290,22 @@ export async function getCommits(username: string): Promise<CommitData> {
     });
 
     if (commits.length === 0) {
-      return {
+      const result: CommitData = {
         found: false,
         error: "No public commits found for this user (or indexing is delayed).",
         errorKind: "empty",
         commits: [],
       };
+      setCachedCommitSearch(cacheKey, result);
+      return result;
     }
 
-    return {
+    const result: CommitData = {
       found: true,
       commits: commits
     };
+    setCachedCommitSearch(cacheKey, result);
+    return result;
 
   } catch (error: unknown) {
     let errorMessage = "Failed to fetch commits.";
@@ -326,7 +345,7 @@ export async function getCommits(username: string): Promise<CommitData> {
           status: typeof status === "number" ? status : undefined,
           message: errorDetails.message,
         },
-      }, error);
+      });
       errorMessage = "GitHub is temporarily unavailable. Please try again soon.";
       return { found: false, error: errorMessage, errorKind: "unavailable", commits: [] };
     }
@@ -338,7 +357,7 @@ export async function getCommits(username: string): Promise<CommitData> {
           status: typeof status === "number" ? status : undefined,
           message: errorDetails.message,
         },
-      }, error);
+      });
     }
 
     if (status === 422) {

--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -34,6 +34,7 @@ describe("GET /api/health", () => {
         },
       },
     });
+    expect(body.runtime).toBeUndefined();
     expect(Date.parse(body.timestamp)).not.toBeNaN();
     expect(JSON.stringify(body)).not.toContain("secret-token");
   });

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -7,9 +7,6 @@ type HealthPayload = {
   timestamp: string;
   environment: string;
   commit: string;
-  runtime: {
-    node: string;
-  };
   checks: {
     siteUrl: {
       configured: boolean;
@@ -22,6 +19,12 @@ function getPublicSiteUrl() {
   return process.env.NEXT_PUBLIC_SITE_URL?.trim() || null;
 }
 
+function getShortCommit() {
+  const commit = process.env.VERCEL_GIT_COMMIT_SHA?.trim();
+
+  return commit ? commit.slice(0, 7) : "local";
+}
+
 export function buildHealthPayload(now = new Date()): HealthPayload {
   const siteUrl = getPublicSiteUrl();
 
@@ -30,10 +33,7 @@ export function buildHealthPayload(now = new Date()): HealthPayload {
     service: "my-first-commit",
     timestamp: now.toISOString(),
     environment: process.env.VERCEL_ENV?.trim() || "local",
-    commit: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || "local",
-    runtime: {
-      node: process.version,
-    },
+    commit: getShortCommit(),
     checks: {
       siteUrl: {
         configured: Boolean(siteUrl),

--- a/app/commitSearchCache.test.ts
+++ b/app/commitSearchCache.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { CommitData } from "./actions";
+import {
+  clearCommitSearchCache,
+  getCachedCommitSearch,
+  setCachedCommitSearch,
+} from "./commitSearchCache";
+
+const commitSearchResult: CommitData = {
+  found: true,
+  commits: [
+    {
+      message: "Initial commit",
+      date: "2024-01-02T00:00:00Z",
+      html_url: "https://github.com/octo/repo/commit/abcdef123456",
+      sha: "abcdef123456",
+      repository: {
+        name: "repo",
+        owner: "octo",
+        full_name: "octo/repo",
+      },
+      author: {
+        login: "octo",
+        avatar_url: "https://github.com/octo.png",
+        html_url: "https://github.com/octo",
+      },
+    },
+  ],
+};
+
+describe("commit search cache", () => {
+  beforeEach(() => {
+    clearCommitSearchCache();
+  });
+
+  it("returns copies so callers cannot mutate cached results", () => {
+    setCachedCommitSearch("octo", commitSearchResult, 1_000);
+
+    const cachedResult = getCachedCommitSearch("octo", 1_100);
+    cachedResult?.commits.push({
+      ...commitSearchResult.commits[0],
+      sha: "mutated",
+    });
+    if (cachedResult?.commits[0]) {
+      cachedResult.commits[0].repository.name = "mutated";
+    }
+
+    expect(getCachedCommitSearch("octo", 1_200)).toEqual(commitSearchResult);
+  });
+
+  it("caps the number of cached entries", () => {
+    for (let index = 0; index < 101; index += 1) {
+      setCachedCommitSearch(`octo-${index}`, commitSearchResult, 1_000);
+    }
+
+    expect(getCachedCommitSearch("octo-0", 1_100)).toBeNull();
+    expect(getCachedCommitSearch("octo-100", 1_100)).toEqual(commitSearchResult);
+  });
+
+  it("refreshes recently read entries before pruning the oldest entries", () => {
+    for (let index = 0; index < 100; index += 1) {
+      setCachedCommitSearch(`octo-${index}`, commitSearchResult, 1_000);
+    }
+
+    getCachedCommitSearch("octo-0", 1_100);
+    setCachedCommitSearch("octo-100", commitSearchResult, 1_200);
+
+    expect(getCachedCommitSearch("octo-0", 1_300)).toEqual(commitSearchResult);
+    expect(getCachedCommitSearch("octo-1", 1_300)).toBeNull();
+  });
+});

--- a/app/commitSearchCache.ts
+++ b/app/commitSearchCache.ts
@@ -1,6 +1,7 @@
 import type { CommitData } from "./actions";
 
 const COMMIT_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000;
+const COMMIT_SEARCH_CACHE_MAX_ENTRIES = 100;
 
 type CacheEntry = {
   expiresAt: number;
@@ -8,6 +9,33 @@ type CacheEntry = {
 };
 
 const commitSearchCache = new Map<string, CacheEntry>();
+
+function copyCommitSearchResult(result: CommitData): CommitData {
+  return {
+    ...result,
+    commits: result.commits.map((commit) => ({
+      ...commit,
+      repository: { ...commit.repository },
+      author: { ...commit.author },
+    })),
+  };
+}
+
+function pruneExpiredEntries(now: number) {
+  for (const [cacheKey, cached] of commitSearchCache) {
+    if (cached.expiresAt <= now) {
+      commitSearchCache.delete(cacheKey);
+    }
+  }
+}
+
+function pruneOldestEntries() {
+  while (commitSearchCache.size > COMMIT_SEARCH_CACHE_MAX_ENTRIES) {
+    const oldestCacheKey = commitSearchCache.keys().next().value;
+    if (oldestCacheKey === undefined) return;
+    commitSearchCache.delete(oldestCacheKey);
+  }
+}
 
 export function getCachedCommitSearch(cacheKey: string, now = Date.now()) {
   const cached = commitSearchCache.get(cacheKey);
@@ -19,19 +47,23 @@ export function getCachedCommitSearch(cacheKey: string, now = Date.now()) {
     return null;
   }
 
-  return cached.result;
+  commitSearchCache.delete(cacheKey);
+  commitSearchCache.set(cacheKey, cached);
+
+  return copyCommitSearchResult(cached.result);
 }
 
 export function setCachedCommitSearch(cacheKey: string, result: CommitData, now = Date.now()) {
   if (!result.found && result.errorKind !== "empty") return;
 
+  pruneExpiredEntries(now);
   commitSearchCache.set(cacheKey, {
     expiresAt: now + COMMIT_SEARCH_CACHE_TTL_MS,
-    result,
+    result: copyCommitSearchResult(result),
   });
+  pruneOldestEntries();
 }
 
 export function clearCommitSearchCache() {
   commitSearchCache.clear();
 }
-

--- a/app/commitSearchCache.ts
+++ b/app/commitSearchCache.ts
@@ -1,0 +1,37 @@
+import type { CommitData } from "./actions";
+
+const COMMIT_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type CacheEntry = {
+  expiresAt: number;
+  result: CommitData;
+};
+
+const commitSearchCache = new Map<string, CacheEntry>();
+
+export function getCachedCommitSearch(cacheKey: string, now = Date.now()) {
+  const cached = commitSearchCache.get(cacheKey);
+
+  if (!cached) return null;
+
+  if (cached.expiresAt <= now) {
+    commitSearchCache.delete(cacheKey);
+    return null;
+  }
+
+  return cached.result;
+}
+
+export function setCachedCommitSearch(cacheKey: string, result: CommitData, now = Date.now()) {
+  if (!result.found && result.errorKind !== "empty") return;
+
+  commitSearchCache.set(cacheKey, {
+    expiresAt: now + COMMIT_SEARCH_CACHE_TTL_MS,
+    result,
+  });
+}
+
+export function clearCommitSearchCache() {
+  commitSearchCache.clear();
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useRef, useState, useTransition } from 'react';
 import { getCommits, CommitData } from './actions';
+import { getUsernameValidationMessage, normalizeGitHubUsername } from "./username";
 import FirstCommitDisplay from '@/components/FirstCommitDisplay';
 import { track } from "@vercel/analytics";
 import { FaGithub } from "react-icons/fa";
@@ -19,18 +20,6 @@ function trackAppEvent(name: string, properties?: Record<string, string | number
   } catch {
     // Analytics should never interrupt the search experience.
   }
-}
-
-function getUsernameValidationMessage(value: string) {
-  const username = value.trim();
-
-  if (!username) return "";
-  if (username.length > 39) return "GitHub usernames must be 39 characters or fewer.";
-  if (!/^[a-zA-Z0-9-]+$/.test(username)) return "Use only letters, numbers, and hyphens.";
-  if (username.startsWith("-") || username.endsWith("-")) return "GitHub usernames cannot start or end with a hyphen.";
-  if (username.includes("--")) return "GitHub usernames cannot include consecutive hyphens.";
-
-  return "";
 }
 
 function updateSharedSearchUrl(username: string) {
@@ -180,7 +169,7 @@ export default function Home() {
   };
 
   const searchCommits = useCallback((searchUsername: string, options: { updateUrl?: boolean } = {}) => {
-    const trimmedUsername = searchUsername.trim();
+    const trimmedUsername = normalizeGitHubUsername(searchUsername);
     if (!trimmedUsername) return;
     if (getUsernameValidationMessage(trimmedUsername)) return;
     if (options.updateUrl) updateSharedSearchUrl(trimmedUsername);

--- a/app/privacy/page.test.tsx
+++ b/app/privacy/page.test.tsx
@@ -10,6 +10,7 @@ describe("PrivacyPage", () => {
     expect(screen.getByRole("link", { name: /back to search/i })).toHaveAttribute("href", "/");
     expect(screen.getByText(/sent to GitHub/i)).toBeInTheDocument();
     expect(screen.getByText(/my-first-commit:recent-searches/i)).toBeInTheDocument();
+    expect(screen.getByText(/short-lived memory cache/i)).toBeInTheDocument();
     expect(screen.getByText(/analytics events do not include the searched GitHub username/i)).toBeInTheDocument();
     expect(screen.getByText(/never sent to the browser/i)).toBeInTheDocument();
   });

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -33,6 +33,9 @@ export default function PrivacyPage() {
           <p className="mt-3 leading-7 text-[var(--github-gray-text)]">
             Successful searches can appear as recent-search shortcuts. Those shortcuts are stored only in this browser using local storage under <code className="font-mono text-sm">my-first-commit:recent-searches</code>.
           </p>
+          <p className="mt-3 leading-7 text-[var(--github-gray-text)]">
+            The server may also keep successful or empty GitHub search results in short-lived memory cache to reduce repeated GitHub API calls. This cache is temporary and is not a database.
+          </p>
         </section>
 
         <section className="mt-8">

--- a/app/username.test.ts
+++ b/app/username.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getUsernameValidationMessage, normalizeGitHubUsername } from "./username";
+
+describe("GitHub username helpers", () => {
+  it("normalizes surrounding whitespace", () => {
+    expect(normalizeGitHubUsername("  octocat  ")).toBe("octocat");
+  });
+
+  it.each([
+    ["octocat", ""],
+    ["octo-cat", ""],
+    ["octo_cat", "Use only letters, numbers, and hyphens."],
+    ["-octo", "GitHub usernames cannot start or end with a hyphen."],
+    ["octo-", "GitHub usernames cannot start or end with a hyphen."],
+    ["octo--cat", "GitHub usernames cannot include consecutive hyphens."],
+    ["a".repeat(40), "GitHub usernames must be 39 characters or fewer."],
+  ])("validates %s", (username, expectedMessage) => {
+    expect(getUsernameValidationMessage(username)).toBe(expectedMessage);
+  });
+});
+

--- a/app/username.ts
+++ b/app/username.ts
@@ -1,0 +1,16 @@
+export function normalizeGitHubUsername(value: string) {
+  return value.trim();
+}
+
+export function getUsernameValidationMessage(value: string) {
+  const username = normalizeGitHubUsername(value);
+
+  if (!username) return "";
+  if (username.length > 39) return "GitHub usernames must be 39 characters or fewer.";
+  if (!/^[a-zA-Z0-9-]+$/.test(username)) return "Use only letters, numbers, and hyphens.";
+  if (username.startsWith("-") || username.endsWith("-")) return "GitHub usernames cannot start or end with a hyphen.";
+  if (username.includes("--")) return "GitHub usernames cannot include consecutive hyphens.";
+
+  return "";
+}
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,14 +9,16 @@ My First Commit is a small Next.js App Router application. It has no database, n
 3. The client validates the username format before submitting.
 4. The client calls the `getCommits` server action in `app/actions.ts`.
 5. The server action queries GitHub's public commit search through Octokit.
-6. The server action maps GitHub results into the app's `CommitData` shape.
-7. The client renders the first public commit and the next several commits in `FirstCommitDisplay`.
-8. Successful searches are stored in browser `localStorage` as recent-search shortcuts.
+6. Successful and empty GitHub search results are cached briefly in memory by normalized username to reduce repeated API calls.
+7. The server action maps GitHub results into the app's `CommitData` shape.
+8. The client renders the first public commit and the next several commits in `FirstCommitDisplay`.
+9. Successful searches are stored in browser `localStorage` as recent-search shortcuts.
 
 ## Data Boundaries
 
 - `GITHUB_TOKEN` is server-side only and is used by Octokit in the server action.
 - Usernames are sent to GitHub to search public commit data.
+- GitHub username validation runs on both the client and server action boundary.
 - Recent searches are stored only in the user's browser under `my-first-commit:recent-searches`.
 - The app does not persist searches, users, commits, or analytics events in its own database.
 
@@ -33,7 +35,7 @@ GitHub API failures are normalized in `app/actions.ts`:
 
 - Empty public search results show a polite empty state.
 - Rate limits, timeouts, unavailable GitHub services, validation failures, and unknown errors show recovery-focused copy.
-- Server-side failures are logged with structured event names and without usernames or tokens.
+- Server-side failures are logged with structured event names and sanitized fields only, without usernames, tokens, or raw Octokit error objects.
 
 ## Operational Checks
 
@@ -42,4 +44,5 @@ GitHub Actions and Vercel cover the main production path:
 - `CI / validate` runs lint, unit tests, build, and browser checks.
 - Vercel deploys previews and production.
 - `Production Health Check` runs Playwright against the public production URL after successful production deployments.
+- `Promote Production Release` creates a tag and GitHub release only after the matching `main` CI run and production health check pass.
 - `/api/health` exposes runtime status without secrets.

--- a/docs/production.md
+++ b/docs/production.md
@@ -15,7 +15,7 @@ The app also exposes a lightweight runtime health endpoint:
 https://my-first-commit-eta.vercel.app/api/health
 ```
 
-It returns JSON status, deployment metadata, Node runtime version, and whether the public site URL is configured. It does not expose server-side secrets.
+It returns JSON status, deployment metadata, and whether the public site URL is configured. It does not expose server-side secrets or detailed runtime versions.
 
 ## Required Configuration
 
@@ -41,8 +41,9 @@ PRODUCTION_BASE_URL=https://my-first-commit-eta.vercel.app
 3. Vercel builds and deploys production.
 4. GitHub receives a production `deployment_status` event.
 5. The `Production Health Check` workflow runs Playwright against `PRODUCTION_BASE_URL`.
+6. The `Promote Production Release` workflow creates the deployment tag and GitHub release only after the matching `main` CI run and production health check pass.
 
-The production deploy is healthy when both `CI / validate` and `Production Health Check` pass on `main`.
+The production deploy is healthy when `CI / validate`, `Production Health Check`, and `Promote Production Release` pass on `main`.
 
 ## Release Checklist
 
@@ -180,8 +181,9 @@ The app sets baseline security headers from `next.config.ts`:
 - `Referrer-Policy: strict-origin-when-cross-origin`
 - `Permissions-Policy` disabling camera, microphone, geolocation, and payment APIs
 - `X-Frame-Options: DENY`
+- `Content-Security-Policy-Report-Only` for CSP tuning without blocking production traffic
 
-Content Security Policy is intentionally not enabled yet. Next.js and Vercel Analytics need a carefully tuned policy so production scripts, generated images, and analytics continue to work without weakening the policy into noise.
+Content Security Policy is currently report-only. Review Vercel logs and browser reports before moving from report-only to enforcement.
 
 ## Accessibility Checks
 
@@ -203,6 +205,8 @@ my-first-commit:recent-searches
 ```
 
 This powers the recent-search shortcuts. Clearing browser site data removes the list.
+
+Successful and empty GitHub search results may also be cached briefly in server memory by normalized username to reduce repeated GitHub API calls. This cache is ephemeral and is not a database.
 
 ## Troubleshooting
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,7 +19,7 @@ Use this checklist when cutting a new My First Commit release.
 
 ## Publish Release
 
-Production releases are created automatically after a merge to `main`, a successful Vercel production deployment, and a passing `Production Health Check`. The `Promote Production Release` workflow creates both the Git tag and the GitHub release. The automatic tag format is:
+Production releases are created automatically after a merge to `main`, a successful `CI / validate` run, a successful Vercel production deployment, and a passing `Production Health Check`. The `Promote Production Release` workflow creates both the Git tag and the GitHub release. The automatic tag format is:
 
 ```text
 vX.Y.Z-<deployed-short-sha>

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,18 @@ const isProductionDeployment = process.env.VERCEL_ENV === "production";
 const appReleaseUrl = process.env.NEXT_PUBLIC_APP_RELEASE_URL
   ?? (shortCommitSha && isProductionDeployment ? `https://github.com/scottdensmore/my-first-commit/releases/tag/${appRelease}` : "");
 
+const contentSecurityPolicyReportOnly = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "img-src 'self' data: blob: https://github.com https://avatars.githubusercontent.com",
+  "font-src 'self' data:",
+  "style-src 'self' 'unsafe-inline'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com",
+  "connect-src 'self' https://vitals.vercel-insights.com https://*.vercel-insights.com",
+].join("; ");
+
 const securityHeaders = [
   {
     key: "X-Content-Type-Options",
@@ -32,6 +44,10 @@ const securityHeaders = [
   {
     key: "X-Frame-Options",
     value: "DENY",
+  },
+  {
+    key: "Content-Security-Policy-Report-Only",
+    value: contentSecurityPolicyReportOnly,
   },
 ];
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -12,6 +12,8 @@ function expectSecurityHeaders(response: APIResponse) {
   expect(headers["permissions-policy"]).toContain("geolocation=()");
   expect(headers["permissions-policy"]).toContain("payment=()");
   expect(headers["x-frame-options"]).toBe("DENY");
+  expect(headers["content-security-policy-report-only"]).toContain("default-src 'self'");
+  expect(headers["content-security-policy-report-only"]).toContain("frame-ancestors 'none'");
 }
 
 async function searchForUsername(page: Page, username: string) {


### PR DESCRIPTION
## Summary
Tighten the app boundaries found in the production-readiness pass: validate search input on the server, sanitize GitHub error logs, reduce repeated GitHub calls with a short-lived cache, limit public health metadata, add CSP reporting, and harden the production release workflow.

## Changes
- Share GitHub username normalization/validation between the client and server action
- Add server-side rejection for invalid usernames before calling GitHub
- Add a small in-memory search cache for successful and empty results
- Sanitize GitHub error logging so raw Octokit error objects are not logged
- Prefer committer dates to match the GitHub search sort order
- Add CSP report-only headers and E2E coverage for them
- Trim health endpoint metadata to avoid exposing runtime details or full commit SHAs
- Require successful main CI before automatic production release tagging and serialize release promotion per deployed SHA
- Update docs, changelog, and privacy copy for the new behavior

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - npm test
  - npm run lint
  - npm audit
  - npm run build
  - npm run test:e2e

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #