### PR TITLE
Refactor homepage search flow for maintainability

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,12 +1,13 @@
-'use server'
+"use server";
 
 import { Octokit } from "octokit";
+import type { CommitData, CommitInfo } from "./commitTypes";
 import { getCachedCommitSearch, setCachedCommitSearch } from "./commitSearchCache";
 import { logger } from "./logger";
 import { getUsernameValidationMessage, normalizeGitHubUsername } from "./username";
 
 const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN 
+  auth: process.env.GITHUB_TOKEN,
 });
 
 const GITHUB_SEARCH_TIMEOUT_MS = 10_000;
@@ -18,30 +19,6 @@ type GitHubErrorDetails = {
   rateLimitReset?: string;
   status?: unknown;
 };
-
-export interface CommitInfo {
-    message: string;
-    date: string;
-    html_url: string;
-    sha: string;
-    repository: {
-      name: string;
-      owner: string;
-      full_name: string;
-    };
-    author: {
-      login: string;
-      avatar_url: string;
-      html_url: string;
-    };
-}
-
-export interface CommitData {
-  found: boolean;
-  error?: string;
-  errorKind?: "empty" | "rate_limit" | "timeout" | "unavailable" | "validation" | "unknown";
-  commits: CommitInfo[];
-}
 
 function getE2eCommitSearchResult(username: string): CommitData | null {
   if (!E2E_COMMIT_SEARCH_MOCKS_ENABLED) return null;
@@ -118,12 +95,13 @@ function getGitHubErrorDetails(error: unknown): GitHubErrorDetails {
   const message = "message" in error && typeof error.message === "string"
     ? error.message
     : undefined;
-  const headers = "response" in error
-    && typeof error.response === "object"
-    && error.response !== null
-    && "headers" in error.response
-    && typeof error.response.headers === "object"
-    && error.response.headers !== null
+  const headers =
+    "response" in error &&
+    typeof error.response === "object" &&
+    error.response !== null &&
+    "headers" in error.response &&
+    typeof error.response.headers === "object" &&
+    error.response.headers !== null
       ? error.response.headers as Record<string, string | undefined>
       : undefined;
 
@@ -144,7 +122,12 @@ function isGitHubRateLimitError(errorDetails: GitHubErrorDetails) {
 }
 
 function isTimeoutError(error: unknown, errorDetails: GitHubErrorDetails) {
-  if (typeof error === "object" && error !== null && "name" in error && error.name === "AbortError") {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "AbortError"
+  ) {
     return true;
   }
 
@@ -253,15 +236,17 @@ export async function getCommits(username: string): Promise<CommitData> {
   if (cachedCommitSearch) return cachedCommitSearch;
 
   try {
-    const response = await withTimeoutSignal((signal) => octokit.rest.search.commits({
-      q: `author:${normalizedUsername}`,
-      sort: 'committer-date',
-      order: 'asc',
-      per_page: 10,
-      request: {
-        signal,
-      },
-    }));
+    const response = await withTimeoutSignal((signal) =>
+      octokit.rest.search.commits({
+        q: `author:${normalizedUsername}`,
+        sort: "committer-date",
+        order: "asc",
+        per_page: 10,
+        request: {
+          signal,
+        },
+      }),
+    );
 
     const items = response.data.items;
 
@@ -302,11 +287,10 @@ export async function getCommits(username: string): Promise<CommitData> {
 
     const result: CommitData = {
       found: true,
-      commits: commits
+      commits,
     };
     setCachedCommitSearch(cacheKey, result);
     return result;
-
   } catch (error: unknown) {
     let errorMessage = "Failed to fetch commits.";
     const errorDetails = getGitHubErrorDetails(error);
@@ -350,21 +334,19 @@ export async function getCommits(username: string): Promise<CommitData> {
       return { found: false, error: errorMessage, errorKind: "unavailable", commits: [] };
     }
 
-    {
-      logger.error({
-        event: "github_commit_search_failed",
-        fields: {
-          status: typeof status === "number" ? status : undefined,
-          message: errorDetails.message,
-        },
-      });
-    }
+    logger.error({
+      event: "github_commit_search_failed",
+      fields: {
+        status: typeof status === "number" ? status : undefined,
+        message: errorDetails.message,
+      },
+    });
 
     if (status === 422) {
       errorMessage = "Validation failed. User might not exist.";
       return { found: false, error: errorMessage, errorKind: "validation", commits: [] };
     }
-    
+
     return { found: false, error: errorMessage, errorKind: "unknown", commits: [] };
   }
 }

--- a/app/commitSearchCache.test.ts
+++ b/app/commitSearchCache.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import type { CommitData } from "./actions";
+import type { CommitData } from "./commitTypes";
 import {
   clearCommitSearchCache,
   getCachedCommitSearch,

--- a/app/commitSearchCache.ts
+++ b/app/commitSearchCache.ts
@@ -1,4 +1,4 @@
-import type { CommitData } from "./actions";
+import type { CommitData } from "./commitTypes";
 
 const COMMIT_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000;
 const COMMIT_SEARCH_CACHE_MAX_ENTRIES = 100;

--- a/app/commitTypes.ts
+++ b/app/commitTypes.ts
@@ -1,0 +1,31 @@
+export type CommitInfo = {
+  message: string;
+  date: string;
+  html_url: string;
+  sha: string;
+  repository: {
+    name: string;
+    owner: string;
+    full_name: string;
+  };
+  author: {
+    login: string;
+    avatar_url: string;
+    html_url: string;
+  };
+};
+
+export type CommitErrorKind =
+  | "empty"
+  | "rate_limit"
+  | "timeout"
+  | "unavailable"
+  | "validation"
+  | "unknown";
+
+export type CommitData = {
+  found: boolean;
+  error?: string;
+  errorKind?: CommitErrorKind;
+  commits: CommitInfo[];
+};

--- a/app/home/SearchErrorState.tsx
+++ b/app/home/SearchErrorState.tsx
@@ -1,0 +1,79 @@
+import type { CommitData } from "../commitTypes";
+import {
+  canRetryCommitSearch,
+  getResultMessage,
+  isEmptyCommitSearchResult,
+} from "./resultMessages";
+import SearchShortcutSection from "./SearchShortcutSection";
+
+type SearchErrorStateProps = {
+  result: CommitData;
+  exampleUsernames: string[];
+  isPending: boolean;
+  lastSearchedUsername: string;
+  onRetry: (username: string) => void;
+  onReset: () => void;
+  onExampleSearch: (username: string) => void;
+};
+
+export default function SearchErrorState({
+  result,
+  exampleUsernames,
+  isPending,
+  lastSearchedUsername,
+  onRetry,
+  onReset,
+  onExampleSearch,
+}: SearchErrorStateProps) {
+  const isEmptyResult = isEmptyCommitSearchResult(result);
+  const canRetry = canRetryCommitSearch(result);
+  const resultMessage = getResultMessage(result);
+
+  return (
+    <div
+      role={isEmptyResult ? "status" : "alert"}
+      aria-live={isEmptyResult ? "polite" : undefined}
+      className={`mt-8 w-full max-w-md rounded-md border p-5 text-left shadow-sm ${isEmptyResult ? "border-[var(--github-border)] bg-[var(--github-gray-light)] text-[var(--github-gray-dark)]" : "border-red-200 bg-red-50 text-red-800"}`}
+    >
+      <h2 className="text-base font-semibold text-[var(--github-gray-dark)]">
+        {resultMessage.title}
+      </h2>
+      <p className="mt-2 text-sm text-[var(--github-gray-text)]">
+        {resultMessage.description}
+      </p>
+      {isEmptyResult ? (
+        <div className="mt-4 rounded-md border border-[var(--github-border)] bg-white p-3">
+          <h3 className="text-sm font-semibold text-[var(--github-gray-dark)]">
+            Check a known public profile
+          </h3>
+          <SearchShortcutSection
+            title="Examples"
+            usernames={exampleUsernames}
+            onSearch={onExampleSearch}
+            getButtonLabel={(username) => `@${username}`}
+            buttonAriaLabel={(username) => `Search example username ${username}`}
+          />
+        </div>
+      ) : null}
+      <div className="mt-4 flex flex-wrap gap-2">
+        {canRetry ? (
+          <button
+            type="button"
+            onClick={() => onRetry(lastSearchedUsername)}
+            disabled={isPending || !lastSearchedUsername}
+            className="inline-flex items-center justify-center rounded-md bg-[var(--github-green)] px-3 py-2 text-sm font-semibold text-white hover:bg-[var(--github-green-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--github-green)] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Try again
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={onReset}
+          className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-2 text-sm font-semibold text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+        >
+          Edit username
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/home/SearchForm.tsx
+++ b/app/home/SearchForm.tsx
@@ -1,0 +1,83 @@
+import type { FormEvent, RefObject } from "react";
+
+type SearchFormProps = {
+  username: string;
+  validationMessage: string;
+  canSearch: boolean;
+  isPending: boolean;
+  searchInputRef: RefObject<HTMLInputElement | null>;
+  onSubmit: (event: FormEvent) => void;
+  onUsernameChange: (value: string) => void;
+};
+
+export default function SearchForm({
+  username,
+  validationMessage,
+  canSearch,
+  isPending,
+  searchInputRef,
+  onSubmit,
+  onUsernameChange,
+}: SearchFormProps) {
+  const usernameDescriptionIds = validationMessage
+    ? "username-hint username-validation"
+    : "username-hint";
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      role="search"
+      aria-label="GitHub commit search"
+      aria-busy={isPending}
+      className="w-full max-w-md flex flex-col gap-2 sm:flex-row"
+    >
+      <div className="relative flex-1">
+        <label htmlFor="commit-search" className="sr-only">
+          GitHub username
+        </label>
+        <div className="relative">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-[var(--github-gray-text)]">
+            <span className="font-mono text-sm">@</span>
+          </div>
+          <input
+            ref={searchInputRef}
+            id="commit-search"
+            name="commit-search"
+            type="search"
+            value={username}
+            onInput={(event) => onUsernameChange(event.currentTarget.value)}
+            placeholder="username"
+            aria-describedby={usernameDescriptionIds}
+            aria-invalid={Boolean(validationMessage)}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="none"
+            spellCheck={false}
+            className={`block h-12 w-full rounded-md border bg-white py-3 pl-7 pr-3 leading-5 text-[var(--github-gray-dark)] placeholder-gray-400 shadow-sm focus:border-transparent focus:outline-none focus:ring-2 sm:text-sm ${validationMessage ? "border-red-300 focus:ring-red-500" : "border-[var(--github-border)] focus:ring-[var(--github-blue)]"}`}
+            autoFocus
+          />
+        </div>
+        <p id="username-hint" className="mt-2 text-xs text-[var(--github-gray-text)]">
+          GitHub usernames can use letters, numbers, or single hyphens.
+        </p>
+        {validationMessage ? (
+          <p
+            id="username-validation"
+            role="status"
+            aria-live="polite"
+            className="mt-2 text-xs font-medium text-red-700"
+          >
+            {validationMessage}
+          </p>
+        ) : null}
+      </div>
+      <button
+        type="submit"
+        disabled={!canSearch}
+        className="inline-flex h-12 items-center justify-center rounded-md border border-transparent bg-[var(--github-green)] px-6 text-base font-medium text-white shadow-sm transition-colors hover:bg-[var(--github-green-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--github-green)] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:self-start"
+      >
+        {isPending ? "Searching..." : "Search"}
+      </button>
+    </form>
+  );
+}

--- a/app/home/SearchResults.tsx
+++ b/app/home/SearchResults.tsx
@@ -1,0 +1,99 @@
+import { GoCopy } from "react-icons/go";
+import FirstCommitDisplay from "@/components/FirstCommitDisplay";
+import type { CommitInfo } from "../commitTypes";
+import { getRepositoryUrl } from "./sharedSearch";
+
+type SearchResultsProps = {
+  commits: CommitInfo[];
+  lastSearchedUsername: string;
+  shareStatus: string;
+  onCopy: () => void;
+};
+
+export default function SearchResults({
+  commits,
+  lastSearchedUsername,
+  shareStatus,
+  onCopy,
+}: SearchResultsProps) {
+  const firstCommit = commits[0];
+  if (!firstCommit) return null;
+
+  const uniqueRepositoryCount = new Set(
+    commits.map((commit) => commit.repository.full_name),
+  ).size;
+
+  return (
+    <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 w-full flex flex-col items-center pb-12 pt-8">
+      <div className="mb-6 w-full max-w-2xl text-left">
+        <h1 className="text-2xl font-bold text-[var(--github-gray-dark)]">
+          First public commit found
+        </h1>
+        <p className="mt-2 text-sm text-[var(--github-gray-dark)]">
+          Earliest indexed public commit for @{lastSearchedUsername} appears in{" "}
+          <a
+            href={getRepositoryUrl(firstCommit.repository.full_name)}
+            className="font-semibold text-[var(--github-blue)] hover:underline"
+          >
+            {firstCommit.repository.full_name}
+          </a>
+          {uniqueRepositoryCount > 1
+            ? `, with nearby early commits across ${uniqueRepositoryCount} repositories.`
+            : "."}
+        </p>
+        <p className="mt-2 text-sm text-[var(--github-gray-text)]">
+          GitHub search may miss older commits when indexing is incomplete,
+          delayed, or author metadata changed.
+        </p>
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onCopy}
+            className="inline-flex items-center justify-center gap-1.5 rounded-md border border-[var(--github-border)] bg-white px-3 py-2 text-sm font-semibold text-[var(--github-gray-dark)] shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+          >
+            <GoCopy aria-hidden="true" />
+            Copy result
+          </button>
+          {shareStatus ? (
+            <span
+              role="status"
+              aria-live="polite"
+              className="text-sm font-medium text-[var(--github-gray-text)]"
+            >
+              {shareStatus}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="relative w-full max-w-2xl">
+        <div className="absolute bottom-0 left-8 top-10 -z-10 hidden w-0.5 bg-[var(--github-border)] sm:block" />
+
+        <div className="flex flex-col gap-0">
+          <div className="mb-8 flex gap-4">
+            <div className="mt-12 hidden flex-col items-center sm:flex">
+              <div className="h-4 w-4 rounded-sm border border-[var(--github-green-hover)] bg-[var(--github-green)] shadow-sm" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <FirstCommitDisplay data={firstCommit} isMain />
+            </div>
+          </div>
+
+          {commits.slice(1).map((commit) => (
+            <div
+              key={`${commit.repository.full_name}-${commit.sha}`}
+              className="mb-4 flex gap-4"
+            >
+              <div className="mt-8 hidden flex-col items-center sm:flex">
+                <div className="h-4 w-4 rounded-sm border border-[var(--github-green-hover)] bg-[var(--github-green)] opacity-70 shadow-sm" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <FirstCommitDisplay data={commit} isMain={false} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/home/SearchShortcutSection.tsx
+++ b/app/home/SearchShortcutSection.tsx
@@ -1,0 +1,58 @@
+type SearchShortcutSectionProps = {
+  title: string;
+  usernames: string[];
+  onSearch: (username: string) => void;
+  getButtonLabel: (username: string) => string;
+  buttonAriaLabel: (username: string) => string;
+  onClear?: () => void;
+};
+
+export default function SearchShortcutSection({
+  title,
+  usernames,
+  onSearch,
+  getButtonLabel,
+  buttonAriaLabel,
+  onClear,
+}: SearchShortcutSectionProps) {
+  if (usernames.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby={`${title.toLowerCase().replace(/\s+/g, "-")}-heading`}
+      className="mt-4 w-full max-w-md"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2
+          id={`${title.toLowerCase().replace(/\s+/g, "-")}-heading`}
+          className="text-xs font-semibold uppercase tracking-normal text-[var(--github-gray-text)]"
+        >
+          {title}
+        </h2>
+        {onClear ? (
+          <button
+            type="button"
+            onClick={onClear}
+            aria-label="Clear recent searches"
+            className="rounded-sm text-xs font-medium text-[var(--github-gray-text)] hover:text-[var(--github-blue)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+          >
+            Clear
+          </button>
+        ) : null}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {usernames.map((username) => (
+          <button
+            key={username}
+            type="button"
+            onClick={() => onSearch(username)}
+            className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+            aria-label={buttonAriaLabel(username)}
+          >
+            {getButtonLabel(username)}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/home/analytics.test.ts
+++ b/app/home/analytics.test.ts
@@ -1,0 +1,17 @@
+import { track } from "@vercel/analytics";
+import { describe, expect, it, vi } from "vitest";
+import { trackAppEvent } from "./analytics";
+
+vi.mock("@vercel/analytics", () => ({
+  track: vi.fn(),
+}));
+
+describe("trackAppEvent", () => {
+  it("swallows analytics failures so optional tracking cannot break the UI", () => {
+    vi.mocked(track).mockImplementation(() => {
+      throw new Error("analytics unavailable");
+    });
+
+    expect(() => trackAppEvent("search_submitted")).not.toThrow();
+  });
+});

--- a/app/home/analytics.ts
+++ b/app/home/analytics.ts
@@ -3,5 +3,9 @@ import { track } from "@vercel/analytics";
 type AppEventProperties = Record<string, string | number | boolean>;
 
 export function trackAppEvent(name: string, properties?: AppEventProperties) {
-  track(name, properties);
+  try {
+    track(name, properties);
+  } catch {
+    return;
+  }
 }

--- a/app/home/analytics.ts
+++ b/app/home/analytics.ts
@@ -1,0 +1,7 @@
+import { track } from "@vercel/analytics";
+
+type AppEventProperties = Record<string, string | number | boolean>;
+
+export function trackAppEvent(name: string, properties?: AppEventProperties) {
+  track(name, properties);
+}

--- a/app/home/browserErrors.ts
+++ b/app/home/browserErrors.ts
@@ -1,0 +1,17 @@
+export function isRecoverableStorageReadError(
+  error: unknown,
+): error is DOMException | SyntaxError {
+  return error instanceof DOMException || error instanceof SyntaxError;
+}
+
+export function isRecoverableStorageWriteError(
+  error: unknown,
+): error is DOMException {
+  return error instanceof DOMException;
+}
+
+export function isRecoverableClipboardWriteError(
+  error: unknown,
+): error is DOMException {
+  return error instanceof DOMException;
+}

--- a/app/home/browserErrors.ts
+++ b/app/home/browserErrors.ts
@@ -1,17 +1,17 @@
 export function isRecoverableStorageReadError(
   error: unknown,
-): error is DOMException | SyntaxError {
-  return error instanceof DOMException || error instanceof SyntaxError;
+): error is Error | DOMException {
+  return error instanceof Error || error instanceof DOMException;
 }
 
 export function isRecoverableStorageWriteError(
   error: unknown,
-): error is DOMException {
-  return error instanceof DOMException;
+): error is Error | DOMException {
+  return error instanceof Error || error instanceof DOMException;
 }
 
 export function isRecoverableClipboardWriteError(
   error: unknown,
-): error is DOMException {
-  return error instanceof DOMException;
+): error is Error | DOMException {
+  return error instanceof Error || error instanceof DOMException;
 }

--- a/app/home/constants.ts
+++ b/app/home/constants.ts
@@ -1,0 +1,3 @@
+export const RECENT_SEARCHES_STORAGE_KEY = "my-first-commit:recent-searches";
+export const MAX_RECENT_SEARCHES = 5;
+export const EXAMPLE_USERNAMES = ["octocat", "torvalds", "gaearon"];

--- a/app/home/recentSearches.test.ts
+++ b/app/home/recentSearches.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearStoredRecentSearches,
+  getStoredRecentSearches,
+  saveStoredRecentSearches,
+} from "./recentSearches";
+
+describe("recentSearches helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("returns an empty list when localStorage.getItem throws a plain Error", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    expect(getStoredRecentSearches()).toEqual([]);
+  });
+
+  it("swallows plain Error failures when saving recent searches", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+
+    expect(() => saveStoredRecentSearches(["octo"])).not.toThrow();
+  });
+
+  it("swallows plain Error failures when clearing recent searches", () => {
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    expect(() => clearStoredRecentSearches()).not.toThrow();
+  });
+});

--- a/app/home/recentSearches.ts
+++ b/app/home/recentSearches.ts
@@ -1,0 +1,64 @@
+import { getUsernameValidationMessage } from "../username";
+import {
+  isRecoverableStorageReadError,
+  isRecoverableStorageWriteError,
+} from "./browserErrors";
+import {
+  MAX_RECENT_SEARCHES,
+  RECENT_SEARCHES_STORAGE_KEY,
+} from "./constants";
+
+export function getStoredRecentSearches() {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const storedSearches = JSON.parse(
+      window.localStorage.getItem(RECENT_SEARCHES_STORAGE_KEY) ?? "[]",
+    );
+    if (!Array.isArray(storedSearches)) return [];
+
+    return storedSearches
+      .filter(
+        (search): search is string =>
+          typeof search === "string" && !getUsernameValidationMessage(search),
+      )
+      .slice(0, MAX_RECENT_SEARCHES);
+  } catch (error) {
+    if (isRecoverableStorageReadError(error)) {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+export function saveStoredRecentSearches(searches: string[]) {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(
+      RECENT_SEARCHES_STORAGE_KEY,
+      JSON.stringify(searches),
+    );
+  } catch (error) {
+    if (isRecoverableStorageWriteError(error)) {
+      return;
+    }
+
+    throw error;
+  }
+}
+
+export function clearStoredRecentSearches() {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.removeItem(RECENT_SEARCHES_STORAGE_KEY);
+  } catch (error) {
+    if (isRecoverableStorageWriteError(error)) {
+      return;
+    }
+
+    throw error;
+  }
+}

--- a/app/home/resultMessages.ts
+++ b/app/home/resultMessages.ts
@@ -1,0 +1,60 @@
+import type { CommitData } from "../commitTypes";
+
+type ResultMessage = {
+  title: string;
+  description: string;
+};
+
+export function getResultMessage(result: CommitData): ResultMessage {
+  switch (result.errorKind) {
+    case "rate_limit":
+      return {
+        title: "GitHub is asking us to slow down.",
+        description:
+          "GitHub temporarily limited commit search requests. Wait a few minutes, then try this username again.",
+      };
+    case "timeout":
+      return {
+        title: "GitHub took too long to respond.",
+        description:
+          "The request timed out before GitHub finished searching. Try again now, or give GitHub a moment if it keeps happening.",
+      };
+    case "unavailable":
+      return {
+        title: "GitHub search is temporarily unavailable.",
+        description:
+          "GitHub returned a temporary service error. Your search is safe to retry once GitHub recovers.",
+      };
+    case "validation":
+      return {
+        title: "GitHub could not validate that search.",
+        description:
+          "Check the username and try again. GitHub may reject searches for users that do not exist or cannot be searched.",
+      };
+    case "empty":
+      return {
+        title: "No public commits found.",
+        description:
+          "Try another username or check back later; GitHub commit search indexing can lag.",
+      };
+    default:
+      return {
+        title: "We could not complete that search.",
+        description:
+          result.error ?? "GitHub commit search failed. Please try again.",
+      };
+  }
+}
+
+export function canRetryCommitSearch(result: CommitData | null) {
+  return (
+    result?.errorKind === "rate_limit" ||
+    result?.errorKind === "timeout" ||
+    result?.errorKind === "unavailable" ||
+    result?.errorKind === "unknown"
+  );
+}
+
+export function isEmptyCommitSearchResult(result: CommitData | null) {
+  return result?.errorKind === "empty";
+}

--- a/app/home/searchExecution.ts
+++ b/app/home/searchExecution.ts
@@ -1,0 +1,65 @@
+import type {
+  Dispatch,
+  SetStateAction,
+  TransitionStartFunction,
+} from "react";
+import { getCommits } from "../actions";
+import type { CommitData } from "../commitTypes";
+import { getUsernameValidationMessage, normalizeGitHubUsername } from "../username";
+import { trackAppEvent } from "./analytics";
+import { MAX_RECENT_SEARCHES } from "./constants";
+import { saveStoredRecentSearches } from "./recentSearches";
+import { updateSharedSearchUrl } from "./sharedSearch";
+
+type SearchHandlers = {
+  startTransition: TransitionStartFunction;
+  setLastSearchedUsername: Dispatch<SetStateAction<string>>;
+  setShareStatus: Dispatch<SetStateAction<string>>;
+  setResult: Dispatch<SetStateAction<CommitData | null>>;
+  setRecentSearches: Dispatch<SetStateAction<string[]>>;
+};
+
+export function runCommitSearch(
+  searchUsername: string,
+  options: { updateUrl?: boolean } = {},
+  {
+    startTransition,
+    setLastSearchedUsername,
+    setShareStatus,
+    setResult,
+    setRecentSearches,
+  }: SearchHandlers,
+) {
+  const trimmedUsername = normalizeGitHubUsername(searchUsername);
+  if (!trimmedUsername) return;
+  if (getUsernameValidationMessage(trimmedUsername)) return;
+  if (options.updateUrl) updateSharedSearchUrl(trimmedUsername);
+
+  trackAppEvent("search_submitted", {
+    source: options.updateUrl ? "user" : "shared_url",
+  });
+  setLastSearchedUsername(trimmedUsername);
+  setShareStatus("");
+  startTransition(async () => {
+    const data = await getCommits(trimmedUsername);
+    setResult(data);
+    trackAppEvent("search_completed", {
+      found: data.found,
+      error_kind: data.errorKind ?? "none",
+      commit_count: data.commits.length,
+    });
+    if (data.found) {
+      setRecentSearches((currentSearches) => {
+        const nextSearches = [
+          trimmedUsername,
+          ...currentSearches.filter(
+            (search) => search.toLowerCase() !== trimmedUsername.toLowerCase(),
+          ),
+        ].slice(0, MAX_RECENT_SEARCHES);
+
+        saveStoredRecentSearches(nextSearches);
+        return nextSearches;
+      });
+    }
+  });
+}

--- a/app/home/sharedSearch.ts
+++ b/app/home/sharedSearch.ts
@@ -1,0 +1,44 @@
+import type { CommitData } from "../commitTypes";
+
+export function updateSharedSearchUrl(username: string) {
+  const url = new URL(window.location.href);
+  url.searchParams.set("user", username);
+  window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+}
+
+export function clearSharedSearchUrl() {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("user");
+  const search = url.searchParams.toString();
+  window.history.replaceState(
+    null,
+    "",
+    `${url.pathname}${search ? `?${search}` : ""}${url.hash}`,
+  );
+}
+
+export function getInitialSharedUsername() {
+  if (typeof window === "undefined") return "";
+
+  return new URLSearchParams(window.location.search).get("user") ?? "";
+}
+
+export function getRepositoryUrl(fullName: string) {
+  return `https://github.com/${fullName}`;
+}
+
+export function buildResultShareText(username: string, result: CommitData) {
+  const firstCommit = result.commits[0];
+  if (!firstCommit) {
+    return `${username}'s first public commit search: ${window.location.href}`;
+  }
+
+  const firstLine = firstCommit.message.split("\n")[0];
+
+  return [
+    `${username}'s first public commit: ${firstLine}`,
+    `Repository: ${firstCommit.repository.full_name}`,
+    `Commit: ${firstCommit.html_url}`,
+    `Search: ${window.location.href}`,
+  ].join("\n");
+}

--- a/app/layout.test.tsx
+++ b/app/layout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import RootLayout, { metadata } from "./layout";
 
@@ -57,13 +57,13 @@ describe("RootLayout", () => {
   });
 
   it("mounts Vercel Analytics globally", () => {
-    render(
+    const html = renderToStaticMarkup(
       <RootLayout>
         <main>Page content</main>
       </RootLayout>,
     );
 
-    expect(screen.getByText("Page content")).toBeInTheDocument();
-    expect(screen.getByTestId("vercel-analytics")).toBeInTheDocument();
+    expect(html).toContain("Page content");
+    expect(html).toContain("data-testid=\"vercel-analytics\"");
   });
 });

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -115,7 +115,7 @@ describe("Home", () => {
     mockGetCommits.mockResolvedValue(commitResult);
     const writeText = vi
       .spyOn(navigator.clipboard, "writeText")
-      .mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
+      .mockRejectedValue(new Error("Denied"));
     const user = userEvent.setup();
     render(<Home />);
 
@@ -225,7 +225,7 @@ describe("Home", () => {
   it("keeps successful searches working when local storage writes fail", async () => {
     mockGetCommits.mockResolvedValue(commitResult);
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
-      throw new DOMException("Storage is unavailable", "QuotaExceededError");
+      throw new Error("Storage is unavailable");
     });
     const user = userEvent.setup();
     render(<Home />);

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -113,7 +113,9 @@ describe("Home", () => {
 
   it("shows a helpful status when copying a result fails", async () => {
     mockGetCommits.mockResolvedValue(commitResult);
-    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(new Error("Denied"));
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
     const user = userEvent.setup();
     render(<Home />);
 
@@ -223,7 +225,7 @@ describe("Home", () => {
   it("keeps successful searches working when local storage writes fail", async () => {
     mockGetCommits.mockResolvedValue(commitResult);
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
-      throw new Error("Storage is unavailable");
+      throw new DOMException("Storage is unavailable", "QuotaExceededError");
     });
     const user = userEvent.setup();
     render(<Home />);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,136 +1,36 @@
-'use client'
+"use client";
 
-import React, { useCallback, useEffect, useRef, useState, useTransition } from 'react';
-import { getCommits, CommitData } from './actions';
-import { getUsernameValidationMessage, normalizeGitHubUsername } from "./username";
-import FirstCommitDisplay from '@/components/FirstCommitDisplay';
-import { track } from "@vercel/analytics";
+import type { FormEvent } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
+import Link from "next/link";
 import { FaGithub } from "react-icons/fa";
-import { GoCopy } from "react-icons/go";
-
-const RECENT_SEARCHES_STORAGE_KEY = "my-first-commit:recent-searches";
-const MAX_RECENT_SEARCHES = 5;
-const EXAMPLE_USERNAMES = ["octocat", "torvalds", "gaearon"];
+import type { CommitData } from "./commitTypes";
+import { trackAppEvent } from "./home/analytics";
+import { EXAMPLE_USERNAMES } from "./home/constants";
+import { isRecoverableClipboardWriteError } from "./home/browserErrors";
+import SearchErrorState from "./home/SearchErrorState";
+import SearchForm from "./home/SearchForm";
+import SearchResults from "./home/SearchResults";
+import SearchShortcutSection from "./home/SearchShortcutSection";
+import {
+  clearStoredRecentSearches,
+  getStoredRecentSearches,
+} from "./home/recentSearches";
+import { runCommitSearch } from "./home/searchExecution";
+import {
+  buildResultShareText,
+  clearSharedSearchUrl,
+  getInitialSharedUsername,
+} from "./home/sharedSearch";
+import { getUsernameValidationMessage } from "./username";
 const APP_RELEASE = process.env.NEXT_PUBLIC_APP_RELEASE ?? "local";
 const APP_RELEASE_URL = process.env.NEXT_PUBLIC_APP_RELEASE_URL ?? "";
 
-function trackAppEvent(name: string, properties?: Record<string, string | number | boolean>) {
-  try {
-    track(name, properties);
-  } catch {
-    // Analytics should never interrupt the search experience.
-  }
-}
-
-function updateSharedSearchUrl(username: string) {
-  const url = new URL(window.location.href);
-  url.searchParams.set("user", username);
-  window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
-}
-
-function clearSharedSearchUrl() {
-  const url = new URL(window.location.href);
-  url.searchParams.delete("user");
-  const search = url.searchParams.toString();
-  window.history.replaceState(null, "", `${url.pathname}${search ? `?${search}` : ""}${url.hash}`);
-}
-
-function getInitialSharedUsername() {
-  if (typeof window === "undefined") return "";
-
-  return new URLSearchParams(window.location.search).get("user") ?? "";
-}
-
-function getStoredRecentSearches() {
-  if (typeof window === "undefined") return [];
-
-  try {
-    const storedSearches = JSON.parse(window.localStorage.getItem(RECENT_SEARCHES_STORAGE_KEY) ?? "[]");
-    if (!Array.isArray(storedSearches)) return [];
-
-    return storedSearches
-      .filter((search): search is string => typeof search === "string" && !getUsernameValidationMessage(search))
-      .slice(0, MAX_RECENT_SEARCHES);
-  } catch {
-    return [];
-  }
-}
-
-function saveStoredRecentSearches(searches: string[]) {
-  if (typeof window === "undefined") return;
-
-  try {
-    window.localStorage.setItem(RECENT_SEARCHES_STORAGE_KEY, JSON.stringify(searches));
-  } catch {
-    // Recent searches are a convenience only; searches should still succeed without storage.
-  }
-}
-
-function clearStoredRecentSearches() {
-  if (typeof window === "undefined") return;
-
-  try {
-    window.localStorage.removeItem(RECENT_SEARCHES_STORAGE_KEY);
-  } catch {
-    // Recent searches are optional and should not affect the search flow.
-  }
-}
-
-function getResultMessage(result: CommitData) {
-  switch (result.errorKind) {
-    case "rate_limit":
-      return {
-        title: "GitHub is asking us to slow down.",
-        description: "GitHub temporarily limited commit search requests. Wait a few minutes, then try this username again.",
-      };
-    case "timeout":
-      return {
-        title: "GitHub took too long to respond.",
-        description: "The request timed out before GitHub finished searching. Try again now, or give GitHub a moment if it keeps happening.",
-      };
-    case "unavailable":
-      return {
-        title: "GitHub search is temporarily unavailable.",
-        description: "GitHub returned a temporary service error. Your search is safe to retry once GitHub recovers.",
-      };
-    case "validation":
-      return {
-        title: "GitHub could not validate that search.",
-        description: "Check the username and try again. GitHub may reject searches for users that do not exist or cannot be searched.",
-      };
-    case "empty":
-      return {
-        title: "No public commits found.",
-        description: "Try another username or check back later; GitHub commit search indexing can lag.",
-      };
-    default:
-      return {
-        title: "We could not complete that search.",
-        description: result.error ?? "GitHub commit search failed. Please try again.",
-      };
-  }
-}
-
-function getRepositoryUrl(fullName: string) {
-  return `https://github.com/${fullName}`;
-}
-
-function buildResultShareText(username: string, result: CommitData) {
-  const firstCommit = result.commits[0];
-  const firstLine = firstCommit.message.split("\n")[0];
-
-  return [
-    `${username}'s first public commit: ${firstLine}`,
-    `Repository: ${firstCommit.repository.full_name}`,
-    `Commit: ${firstCommit.html_url}`,
-    `Search: ${window.location.href}`,
-  ].join("\n");
-}
-
 export default function Home() {
-  const [username, setUsername] = useState(getInitialSharedUsername);
+  const initialSharedUsername = getInitialSharedUsername();
+  const [username, setUsername] = useState(initialSharedUsername);
   const [result, setResult] = useState<CommitData | null>(null);
-  const [lastSearchedUsername, setLastSearchedUsername] = useState('');
+  const [lastSearchedUsername, setLastSearchedUsername] = useState("");
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [shareStatus, setShareStatus] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -150,88 +50,74 @@ export default function Home() {
     }
   }, [result?.found]);
 
-  const rememberRecentSearch = useCallback((searchedUsername: string) => {
-    setRecentSearches((currentSearches) => {
-      const nextSearches = [
-        searchedUsername,
-        ...currentSearches.filter((search) => search.toLowerCase() !== searchedUsername.toLowerCase()),
-      ].slice(0, MAX_RECENT_SEARCHES);
-
-      saveStoredRecentSearches(nextSearches);
-      return nextSearches;
-    });
-  }, []);
-
   const clearRecentSearches = () => {
-    setRecentSearches([]);
-    clearStoredRecentSearches();
-    requestAnimationFrame(() => searchInputRef.current?.focus());
-  };
-
-  const searchCommits = useCallback((searchUsername: string, options: { updateUrl?: boolean } = {}) => {
-    const trimmedUsername = normalizeGitHubUsername(searchUsername);
-    if (!trimmedUsername) return;
-    if (getUsernameValidationMessage(trimmedUsername)) return;
-    if (options.updateUrl) updateSharedSearchUrl(trimmedUsername);
-
-    trackAppEvent("search_submitted", {
-      source: options.updateUrl ? "user" : "shared_url",
-    });
-    setLastSearchedUsername(trimmedUsername);
-    setShareStatus("");
-    startTransition(async () => {
-       const data = await getCommits(trimmedUsername);
-       setResult(data);
-       trackAppEvent("search_completed", {
-        found: data.found,
-        error_kind: data.errorKind ?? "none",
-        commit_count: data.commits.length,
-       });
-       if (data.found) {
-        rememberRecentSearch(trimmedUsername);
-       }
-    });
-  }, [rememberRecentSearch]);
-
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    searchCommits(username, { updateUrl: true });
-  };
-
-  const resetSearch = () => {
-    setResult(null);
-    setShareStatus("");
-    clearSharedSearchUrl();
-    requestAnimationFrame(() => searchInputRef.current?.focus());
+   setRecentSearches([]);
+   clearStoredRecentSearches();
+   focusSearchInput();
   };
 
   useEffect(() => {
-    const sharedUsername = new URLSearchParams(window.location.search).get("user");
-    if (!sharedUsername) return;
+   const sharedUsername = getInitialSharedUsername();
+   if (!sharedUsername) return;
 
-    const autoSearch = window.setTimeout(() => {
-      searchCommits(sharedUsername);
-    }, 0);
+   const autoSearch = window.setTimeout(() => {
+     runCommitSearch(sharedUsername, undefined, {
+       startTransition,
+       setLastSearchedUsername,
+       setShareStatus,
+       setResult,
+       setRecentSearches,
+     });
+   }, 0);
 
-    return () => window.clearTimeout(autoSearch);
-  }, [searchCommits]);
+   return () => window.clearTimeout(autoSearch);
+  }, [startTransition]);
 
-  const isEmptyResult = result?.errorKind === "empty";
-  const canRetrySearch = result?.errorKind === "rate_limit"
-    || result?.errorKind === "timeout"
-    || result?.errorKind === "unavailable"
-    || result?.errorKind === "unknown";
-  const resultMessage = result && !result.found ? getResultMessage(result) : null;
-  const resultStateRole = isEmptyResult ? "status" : "alert";
+  const focusSearchInput = () => {
+   requestAnimationFrame(() => searchInputRef.current?.focus());
+  };
+
+  const handleSearch = (event: FormEvent) => {
+   event.preventDefault();
+   runCommitSearch(username, { updateUrl: true }, {
+     startTransition,
+     setLastSearchedUsername,
+     setShareStatus,
+     setResult,
+     setRecentSearches,
+   });
+  };
+
+  const resetSearch = () => {
+   setResult(null);
+   setShareStatus("");
+   clearSharedSearchUrl();
+   focusSearchInput();
+  };
+
+  const startNewSearch = () => {
+   setResult(null);
+   setUsername("");
+   setLastSearchedUsername("");
+   setShareStatus("");
+   clearSharedSearchUrl();
+   focusSearchInput();
+  };
+
+  const handleShortcutSearch = (shortcutUsername: string) => {
+   setUsername(shortcutUsername);
+   runCommitSearch(shortcutUsername, { updateUrl: true }, {
+     startTransition,
+     setLastSearchedUsername,
+     setShareStatus,
+     setResult,
+     setRecentSearches,
+   });
+  };
+
   const usernameValidationMessage = getUsernameValidationMessage(username);
-  const usernameDescriptionIds = usernameValidationMessage
-    ? "username-hint username-validation"
-    : "username-hint";
-  const canSearch = Boolean(username.trim()) && !usernameValidationMessage && !isPending;
-  const firstCommit = result?.found ? result.commits[0] : null;
-  const uniqueRepositoryCount = result?.found
-    ? new Set(result.commits.map((commit) => commit.repository.full_name)).size
-    : 0;
+  const canSearch =
+    Boolean(username.trim()) && !usernameValidationMessage && !isPending;
 
   const copyResult = async () => {
     if (!result?.found || !navigator.clipboard) {
@@ -241,10 +127,16 @@ export default function Home() {
     }
 
     try {
-      await navigator.clipboard.writeText(buildResultShareText(lastSearchedUsername, result));
+      await navigator.clipboard.writeText(
+        buildResultShareText(lastSearchedUsername, result),
+      );
       setShareStatus("Result copied.");
       trackAppEvent("result_copied");
-    } catch {
+    } catch (error) {
+      if (!isRecoverableClipboardWriteError(error)) {
+        throw error;
+      }
+
       setShareStatus("Could not copy result. Use the commit link instead.");
       trackAppEvent("result_copy_failed");
     }
@@ -254,293 +146,143 @@ export default function Home() {
     <div className="min-h-screen flex flex-col bg-[var(--background)] font-sans">
       {/* Header */}
       <header aria-label="Site header" className="sticky top-0 z-50 py-3 px-6 border-b border-[var(--github-border)] bg-[var(--github-gray-light)] flex items-center justify-between backdrop-blur-sm bg-white/80">
-         <div className="flex items-center gap-2 font-bold text-xl text-[var(--github-gray-dark)]">
-            <FaGithub className="text-3xl" />
-            <span>My First Commit</span>
-         </div>
-         {result?.found && (
-            <button 
-                onClick={() => { setResult(null); setUsername(''); setLastSearchedUsername(''); setShareStatus(''); clearSharedSearchUrl(); }}
-                className="px-3 py-1.5 text-xs font-semibold text-[var(--github-gray-dark)] bg-white border border-[var(--github-border)] rounded-md hover:bg-gray-50 transition-colors shadow-sm"
-            >
-                Search another user
-            </button>
-         )}
+        <div className="flex items-center gap-2 font-bold text-xl text-[var(--github-gray-dark)]">
+         <FaGithub className="text-3xl" />
+         <span>My First Commit</span>
+        </div>
+        {result?.found ? (
+         <button
+           onClick={startNewSearch}
+           className="rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-xs font-semibold text-[var(--github-gray-dark)] shadow-sm transition-colors hover:bg-gray-50"
+         >
+           Search another user
+         </button>
+        ) : null}
       </header>
 
       {/* Main */}
-      <main aria-label="Commit search" className="flex-1 flex flex-col items-center p-4 w-full max-w-4xl mx-auto">
-        
-        {(!result?.found) && (
-            <div className={`text-center mb-8 mt-20 transition-all duration-500 ${isPending ? 'opacity-50' : 'opacity-100'}`}>
-                <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight text-[var(--github-gray-dark)] mb-4">
-                    Discover your origin.
-                </h1>
-                <p className="text-lg text-[var(--github-gray-text)]">
-                    Enter your GitHub username to find your very first public commit.
-                </p>
-            </div>
-        )}
+      <main
+        aria-label="Commit search"
+        className="mx-auto flex w-full max-w-4xl flex-1 flex-col items-center p-4"
+      >
+        {!result?.found ? (
+         <div
+           className={`mb-8 mt-20 text-center transition-all duration-500 ${isPending ? "opacity-50" : "opacity-100"}`}
+         >
+           <h1 className="mb-4 text-3xl font-extrabold tracking-tight text-[var(--github-gray-dark)] sm:text-5xl">
+             Discover your origin.
+           </h1>
+           <p className="text-lg text-[var(--github-gray-text)]">
+             Enter your GitHub username to find your very first public commit.
+           </p>
+         </div>
+        ) : null}
 
-        {/* Search Form */}
-        {!result?.found && (
-        <form
-            onSubmit={handleSearch}
-            role="search"
-            aria-label="GitHub commit search"
-            aria-busy={isPending}
-            className="w-full max-w-md flex flex-col sm:flex-row gap-2"
-        >
-            <div className="relative flex-1">
-                <label htmlFor="commit-search" className="sr-only">
-                    GitHub username
-                </label>
-                <div className="relative">
-                    <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-[var(--github-gray-text)]">
-                        <span className="font-mono text-sm">@</span>
-                    </div>
-                    <input
-                        ref={searchInputRef}
-                        id="commit-search"
-                        name="commit-search"
-                        type="search"
-                        value={username}
-                        onInput={(e) => setUsername(e.currentTarget.value)}
-                        placeholder="username"
-                        aria-describedby={usernameDescriptionIds}
-                        aria-invalid={Boolean(usernameValidationMessage)}
-                        autoComplete="off"
-                        autoCorrect="off"
-                        autoCapitalize="none"
-                        spellCheck={false}
-                        className={`block h-12 w-full rounded-md border bg-white py-3 pl-7 pr-3 leading-5 text-[var(--github-gray-dark)] placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:border-transparent sm:text-sm ${usernameValidationMessage ? 'border-red-300 focus:ring-red-500' : 'border-[var(--github-border)] focus:ring-[var(--github-blue)]'}`}
-                        autoFocus
-                    />
-                </div>
-                <p id="username-hint" className="mt-2 text-xs text-[var(--github-gray-text)]">
-                    GitHub usernames can use letters, numbers, or single hyphens.
-                </p>
-                {usernameValidationMessage && (
-                    <p id="username-validation" role="status" aria-live="polite" className="mt-2 text-xs font-medium text-red-700">
-                        {usernameValidationMessage}
-                    </p>
-                )}
-            </div>
-            <button
-                type="submit"
-                disabled={!canSearch}
-                className="inline-flex h-12 items-center justify-center rounded-md border border-transparent bg-[var(--github-green)] px-6 text-base font-medium text-white shadow-sm transition-colors hover:bg-[var(--github-green-hover)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--github-green)] disabled:cursor-not-allowed disabled:opacity-50 sm:self-start"
-            >
-                {isPending ? 'Searching...' : 'Search'}
-            </button>
-        </form>
-        )}
+        {!result?.found ? (
+         <SearchForm
+           username={username}
+           validationMessage={usernameValidationMessage}
+           canSearch={canSearch}
+           isPending={isPending}
+           searchInputRef={searchInputRef}
+           onSubmit={handleSearch}
+           onUsernameChange={setUsername}
+         />
+        ) : null}
 
-        {!result?.found && recentSearches.length > 0 && (
-            <section aria-labelledby="recent-searches-heading" className="mt-4 w-full max-w-md">
-                <div className="flex items-center justify-between gap-3">
-                    <h2 id="recent-searches-heading" className="text-xs font-semibold uppercase tracking-normal text-[var(--github-gray-text)]">
-                        Recent searches
-                    </h2>
-                    <button
-                        type="button"
-                        onClick={clearRecentSearches}
-                        aria-label="Clear recent searches"
-                        className="text-xs font-medium text-[var(--github-gray-text)] hover:text-[var(--github-blue)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2 rounded-sm"
-                    >
-                        Clear
-                    </button>
-                </div>
-                <div className="mt-2 flex flex-wrap gap-2">
-                    {recentSearches.map((recentUsername) => (
-                        <button
-                            key={recentUsername}
-                            type="button"
-                            onClick={() => {
-                                setUsername(recentUsername);
-                                searchCommits(recentUsername, { updateUrl: true });
-                            }}
-                            className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
-                            aria-label={`Search ${recentUsername} again`}
-                        >
-                            @{recentUsername}
-                        </button>
-                    ))}
-                </div>
-            </section>
-        )}
+        {!result?.found && recentSearches.length > 0 ? (
+         <SearchShortcutSection
+           title="Recent searches"
+           usernames={recentSearches}
+           onSearch={handleShortcutSearch}
+           getButtonLabel={(recentUsername) => `@${recentUsername}`}
+           buttonAriaLabel={(recentUsername) => `Search ${recentUsername} again`}
+           onClear={clearRecentSearches}
+         />
+        ) : null}
 
-        {!result && (
-            <section aria-labelledby="examples-heading" className="mt-6 w-full max-w-md">
-                <h2 id="examples-heading" className="text-xs font-semibold uppercase tracking-normal text-[var(--github-gray-text)]">
-                    Examples
-                </h2>
-                <div className="mt-2 flex flex-wrap gap-2">
-                    {EXAMPLE_USERNAMES.map((exampleUsername) => (
-                        <button
-                            key={exampleUsername}
-                            type="button"
-                            onClick={() => {
-                                setUsername(exampleUsername);
-                                searchCommits(exampleUsername, { updateUrl: true });
-                            }}
-                            className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
-                            aria-label={`Search example username ${exampleUsername}`}
-                        >
-                            @{exampleUsername}
-                        </button>
-                    ))}
-                </div>
-            </section>
-        )}
+        {!result ? (
+         <SearchShortcutSection
+           title="Examples"
+           usernames={EXAMPLE_USERNAMES}
+           onSearch={handleShortcutSearch}
+           getButtonLabel={(exampleUsername) => `@${exampleUsername}`}
+           buttonAriaLabel={(exampleUsername) =>
+             `Search example username ${exampleUsername}`
+           }
+         />
+        ) : null}
 
-        {isPending && !result && (
-            <div role="status" aria-live="polite" className="mt-5 w-full max-w-md rounded-md border border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-3 text-sm text-[var(--github-gray-text)]">
-                Searching GitHub for {lastSearchedUsername}...
-            </div>
-        )}
+        {isPending && !result ? (
+         <div
+           role="status"
+           aria-live="polite"
+           className="mt-5 w-full max-w-md rounded-md border border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-3 text-sm text-[var(--github-gray-text)]"
+         >
+           Searching GitHub for {lastSearchedUsername}...
+         </div>
+        ) : null}
 
-        {/* Empty and Error States */}
-        {result && !result.found && (
-            <div role={resultStateRole} aria-live={isEmptyResult ? "polite" : undefined} className={`mt-8 w-full max-w-md rounded-md border p-5 text-left shadow-sm ${isEmptyResult ? 'border-[var(--github-border)] bg-[var(--github-gray-light)] text-[var(--github-gray-dark)]' : 'border-red-200 bg-red-50 text-red-800'}`}>
-                <h2 className="text-base font-semibold text-[var(--github-gray-dark)]">
-                    {resultMessage?.title}
-                </h2>
-                <p className="mt-2 text-sm text-[var(--github-gray-text)]">
-                    {resultMessage?.description}
-                </p>
-                {isEmptyResult && (
-                    <div className="mt-4 rounded-md border border-[var(--github-border)] bg-white p-3">
-                        <h3 className="text-sm font-semibold text-[var(--github-gray-dark)]">
-                            Check a known public profile
-                        </h3>
-                        <div className="mt-2 flex flex-wrap gap-2">
-                            {EXAMPLE_USERNAMES.map((exampleUsername) => (
-                                <button
-                                    key={exampleUsername}
-                                    type="button"
-                                    onClick={() => {
-                                        setUsername(exampleUsername);
-                                        searchCommits(exampleUsername, { updateUrl: true });
-                                    }}
-                                    className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
-                                    aria-label={`Search example username ${exampleUsername}`}
-                                >
-                                    @{exampleUsername}
-                                </button>
-                            ))}
-                        </div>
-                    </div>
-                )}
-                <div className="mt-4 flex flex-wrap gap-2">
-                    {canRetrySearch && (
-                        <button
-                            type="button"
-                            onClick={() => searchCommits(lastSearchedUsername)}
-                            disabled={isPending || !lastSearchedUsername}
-                            className="inline-flex items-center justify-center rounded-md bg-[var(--github-green)] px-3 py-2 text-sm font-semibold text-white hover:bg-[var(--github-green-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--github-green)] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                        >
-                            Try again
-                        </button>
-                    )}
-                    <button
-                        type="button"
-                        onClick={resetSearch}
-                        className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-2 text-sm font-semibold text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
-                    >
-                        Edit username
-                    </button>
-                </div>
-            </div>
-        )}
+        {result && !result.found ? (
+         <SearchErrorState
+           result={result}
+           exampleUsernames={EXAMPLE_USERNAMES}
+           isPending={isPending}
+           lastSearchedUsername={lastSearchedUsername}
+           onRetry={(searchUsername) =>
+             runCommitSearch(searchUsername, undefined, {
+               startTransition,
+               setLastSearchedUsername,
+               setShareStatus,
+               setResult,
+               setRecentSearches,
+             })
+           }
+           onReset={resetSearch}
+           onExampleSearch={handleShortcutSearch}
+         />
+        ) : null}
 
-        {/* Result State */}
-        {result?.found && result.commits.length > 0 && (
-            <div className="w-full flex flex-col items-center animate-in fade-in slide-in-from-bottom-4 duration-500 pb-12 pt-8">
-                <div className="mb-6 w-full max-w-2xl text-left">
-                    <h1 className="text-2xl font-bold text-[var(--github-gray-dark)]">
-                        First public commit found
-                    </h1>
-                    {firstCommit && (
-                        <p className="mt-2 text-sm text-[var(--github-gray-dark)]">
-                            Earliest indexed public commit for @{lastSearchedUsername} appears in{" "}
-                            <a href={getRepositoryUrl(firstCommit.repository.full_name)} className="font-semibold text-[var(--github-blue)] hover:underline">
-                                {firstCommit.repository.full_name}
-                            </a>
-                            {uniqueRepositoryCount > 1 ? `, with nearby early commits across ${uniqueRepositoryCount} repositories.` : "."}
-                        </p>
-                    )}
-                    <p className="mt-2 text-sm text-[var(--github-gray-text)]">
-                        GitHub search may miss older commits when indexing is incomplete, delayed, or author metadata changed.
-                    </p>
-                    <div className="mt-4 flex flex-wrap items-center gap-2">
-                        <button
-                            type="button"
-                            onClick={copyResult}
-                            className="inline-flex items-center justify-center gap-1.5 rounded-md border border-[var(--github-border)] bg-white px-3 py-2 text-sm font-semibold text-[var(--github-gray-dark)] shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
-                        >
-                            <GoCopy aria-hidden="true" />
-                            Copy result
-                        </button>
-                        {shareStatus && (
-                            <span role="status" aria-live="polite" className="text-sm font-medium text-[var(--github-gray-text)]">
-                                {shareStatus}
-                            </span>
-                        )}
-                    </div>
-                </div>
-                
-                <div className="w-full max-w-2xl relative">
-                    {/* The "Graph" Line */}
-                    <div className="absolute left-8 top-10 bottom-0 w-0.5 bg-[var(--github-border)] -z-10 hidden sm:block"></div>
-                    
-                    <div className="flex flex-col gap-0">
-                        {/* First Commit */}
-                        <div className="flex gap-4 mb-8">
-                            <div className="hidden sm:flex flex-col items-center mt-12">
-                                <div className="w-4 h-4 rounded-sm bg-[var(--github-green)] border border-[var(--github-green-hover)] shadow-sm"></div>
-                            </div>
-                            <div className="flex-1 min-w-0">
-                                <FirstCommitDisplay data={result.commits[0]} isMain={true} />
-                            </div>
-                        </div>
-
-                        {/* Subsequent Commits */}
-                        {result.commits.slice(1).map((commit) => (
-                            <div key={`${commit.repository.full_name}-${commit.sha}`} className="flex gap-4 mb-4">
-                                <div className="hidden sm:flex flex-col items-center mt-8">
-                                    <div className="w-4 h-4 rounded-sm bg-[var(--github-green)] opacity-70 border border-[var(--github-green-hover)] shadow-sm"></div>
-                                </div>
-                                <div className="flex-1 min-w-0">
-                                    <FirstCommitDisplay data={commit} isMain={false} />
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            </div>
-        )}
+        {result?.found && result.commits.length > 0 ? (
+         <SearchResults
+           commits={result.commits}
+           lastSearchedUsername={lastSearchedUsername}
+           shareStatus={shareStatus}
+           onCopy={copyResult}
+         />
+        ) : null}
 
       </main>
 
       {/* Footer */}
-      <footer aria-label="Privacy and GitHub affiliation" className="border-t border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-6 text-center text-xs text-[var(--github-gray-text)]">
+      <footer
+        aria-label="Privacy and GitHub affiliation"
+        className="border-t border-[var(--github-border)] bg-[var(--github-gray-light)] px-4 py-6 text-center text-xs text-[var(--github-gray-text)]"
+      >
         <p className="mx-auto mb-2 max-w-2xl">
-            Privacy: searches are sent to GitHub to find public commits. Recent searches stay in this browser only and are not stored on this app&apos;s server.{" "}
-            <a href="/privacy" className="font-semibold text-[var(--github-blue)] hover:underline">
-                Read the privacy note
-            </a>
-            .
+          Privacy: searches are sent to GitHub to find public commits. Recent
+          searches stay in this browser only and are not stored on this
+          app&apos;s server.{" "}
+          <Link
+            href="/privacy"
+            className="font-semibold text-[var(--github-blue)] hover:underline"
+          >
+            Read the privacy note
+          </Link>
+          .
         </p>
         <p>
-            &copy; {new Date().getFullYear()} Not affiliated with GitHub.{" "}
-            {APP_RELEASE_URL ? (
-                <a href={APP_RELEASE_URL} className="font-semibold text-[var(--github-blue)] hover:underline">
-                    Release {APP_RELEASE}
-                </a>
-            ) : (
-                <span>Release {APP_RELEASE}</span>
-            )}
+          &copy; {new Date().getFullYear()} Not affiliated with GitHub.{" "}
+          {APP_RELEASE_URL ? (
+            <a
+              href={APP_RELEASE_URL}
+              className="font-semibold text-[var(--github-blue)] hover:underline"
+            >
+              Release {APP_RELEASE}
+            </a>
+          ) : (
+            <span>Release {APP_RELEASE}</span>
+          )}
         </p>
       </footer>
     </div>

--- a/components/FirstCommitDisplay.test.tsx
+++ b/components/FirstCommitDisplay.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import FirstCommitDisplay from "./FirstCommitDisplay";
-import type { CommitInfo } from "../app/actions";
+import type { CommitInfo } from "../app/commitTypes";
 
 const commit: CommitInfo = {
   message: "Initial commit\n\nAdd the first files",

--- a/components/FirstCommitDisplay.tsx
+++ b/components/FirstCommitDisplay.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import Image from 'next/image';
-import { CommitInfo } from '../app/actions';
-import { formatDistanceToNow } from 'date-fns';
+import Image from "next/image";
+import { formatDistanceToNow } from "date-fns";
 import { GoGitCommit, GoRepo } from "react-icons/go";
+import type { CommitInfo } from "../app/commitTypes";
 
 interface Props {
   data: CommitInfo;
@@ -30,7 +29,9 @@ export default function FirstCommitDisplay({ data, isMain = true }: Props) {
   const dateObj = new Date(data.date);
   const widthClass = isMain ? "max-w-2xl" : "max-w-xl";
   const shortSha = data.sha.substring(0, 7);
-  
+  const [commitSubject, ...commitBodyLines] = data.message.split("\n");
+  const commitBody = commitBodyLines.join("\n").trim();
+
   return (
     <div className={`w-full ${widthClass} mx-auto border border-[var(--github-border)] rounded-md overflow-hidden font-sans text-sm shadow-sm bg-white`}>
       {/* Repository Header */}
@@ -69,15 +70,15 @@ export default function FirstCommitDisplay({ data, isMain = true }: Props) {
             <div className="flex-1 min-w-0">
                 <div className="mb-1">
                     <a href={data.html_url} className="text-lg font-semibold text-[var(--github-gray-dark)] hover:text-[var(--github-blue)] hover:underline break-words">
-                        {data.message.split('\n')[0]}
+                        {commitSubject}
                     </a>
                 </div>
                 
-                {data.message.split('\n').slice(1).join('').trim().length > 0 && (
+                {commitBody ? (
                     <div className="mt-2 mb-3 text-[var(--github-gray-dark)] font-mono text-xs whitespace-pre-wrap bg-[var(--github-gray-light)] p-2 rounded border border-[var(--github-border)]">
-                        {data.message.split('\n').slice(1).join('\n').trim()}
+                        {commitBody}
                     </div>
-                )}
+                ) : null}
                 
                 <div className="flex flex-wrap items-center gap-1 text-[var(--github-gray-text)] text-xs mt-1">
                     <a href={data.author.html_url} className="font-semibold text-[var(--github-gray-dark)] hover:text-[var(--github-blue)] hover:underline">


### PR DESCRIPTION
## Summary
- extract shared commit and search types into a neutral module
- split homepage logic into focused app/home helpers and components
- simplify commit display parsing and remove the noisy layout test warning

## Validation
- npm run lint
- npm test
- npm run build