### PR TITLE
chore(repo): polish spec, package name, and add helper tests

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
-I want to make a website that allows you to input your github handle and it shows you your first commit with the date   │
-and link to that commit. It is themed in a very GitHub way. This should look very similar to                            │
-https://myfirstcommit.com/.       
+# Spec
 
-The landing page should take in the github handle.
+I want to make a website that allows you to input your GitHub handle and it shows you your first commit, with the date and a link to that commit. It is themed in a very GitHub way. This should look very similar to https://myfirstcommit.com/.
 
-The page to show the first commit information should look like @display.png.
+The landing page should take in the GitHub handle.
+
+The page that shows the first commit information should look like `display.png`.

--- a/app/home/resultMessages.test.ts
+++ b/app/home/resultMessages.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { CommitData, CommitErrorKind } from "../commitTypes";
+import {
+  canRetryCommitSearch,
+  getResultMessage,
+  isEmptyCommitSearchResult,
+} from "./resultMessages";
+
+function errorResult(errorKind?: CommitErrorKind, error?: string): CommitData {
+  return { found: false, errorKind, error, commits: [] };
+}
+
+describe("getResultMessage", () => {
+  it.each([
+    ["rate_limit", "GitHub is asking us to slow down."],
+    ["timeout", "GitHub took too long to respond."],
+    ["unavailable", "GitHub search is temporarily unavailable."],
+    ["validation", "GitHub could not validate that search."],
+    ["empty", "No public commits found."],
+  ] as const)("returns specific copy for %s errors", (errorKind, title) => {
+    expect(getResultMessage(errorResult(errorKind)).title).toBe(title);
+  });
+
+  it("falls back to the result error text for unknown kinds", () => {
+    const message = getResultMessage(errorResult("unknown", "Boom"));
+    expect(message.title).toBe("We could not complete that search.");
+    expect(message.description).toBe("Boom");
+  });
+
+  it("uses generic copy when no error text is present", () => {
+    expect(getResultMessage(errorResult("unknown")).description).toBe(
+      "GitHub commit search failed. Please try again.",
+    );
+  });
+});
+
+describe("canRetryCommitSearch", () => {
+  it.each(["rate_limit", "timeout", "unavailable", "unknown"] as const)(
+    "allows retry for %s",
+    (errorKind) => {
+      expect(canRetryCommitSearch(errorResult(errorKind))).toBe(true);
+    },
+  );
+
+  it.each(["empty", "validation"] as const)("does not allow retry for %s", (errorKind) => {
+    expect(canRetryCommitSearch(errorResult(errorKind))).toBe(false);
+  });
+
+  it("returns false when there is no result", () => {
+    expect(canRetryCommitSearch(null)).toBe(false);
+  });
+});
+
+describe("isEmptyCommitSearchResult", () => {
+  it("is true only for empty results", () => {
+    expect(isEmptyCommitSearchResult(errorResult("empty"))).toBe(true);
+    expect(isEmptyCommitSearchResult(errorResult("timeout"))).toBe(false);
+    expect(isEmptyCommitSearchResult(null)).toBe(false);
+  });
+});

--- a/app/home/searchExecution.test.ts
+++ b/app/home/searchExecution.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getCommits } from "../actions";
+import type { CommitData, CommitInfo } from "../commitTypes";
+import { trackAppEvent } from "./analytics";
+import { saveStoredRecentSearches } from "./recentSearches";
+import { runCommitSearch } from "./searchExecution";
+import { updateSharedSearchUrl } from "./sharedSearch";
+
+vi.mock("../actions", () => ({ getCommits: vi.fn() }));
+vi.mock("./analytics", () => ({ trackAppEvent: vi.fn() }));
+vi.mock("./recentSearches", () => ({ saveStoredRecentSearches: vi.fn() }));
+vi.mock("./sharedSearch", () => ({ updateSharedSearchUrl: vi.fn() }));
+
+const commit: CommitInfo = {
+  message: "Initial commit",
+  date: "2020-01-02T03:04:05Z",
+  html_url: "https://github.com/octocat/repo/commit/abc123",
+  sha: "abc123",
+  repository: { name: "repo", owner: "octocat", full_name: "octocat/repo" },
+  author: {
+    login: "octocat",
+    avatar_url: "https://github.com/ghost.png",
+    html_url: "https://github.com/octocat",
+  },
+};
+
+const foundResult: CommitData = { found: true, commits: [commit] };
+
+// The real `startTransition` runs its callback in a React transition; the test
+// double runs it immediately and exposes the resulting promise so assertions
+// can await the async search work.
+function createHandlers() {
+  let pending: Promise<unknown> | undefined;
+  const handlers = {
+    startTransition: vi.fn((callback: () => unknown) => {
+      pending = Promise.resolve(callback());
+    }),
+    setLastSearchedUsername: vi.fn(),
+    setShareStatus: vi.fn(),
+    setResult: vi.fn(),
+    setRecentSearches: vi.fn(),
+  };
+  return { handlers, settle: () => pending };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runCommitSearch", () => {
+  it("ignores blank usernames", () => {
+    const { handlers } = createHandlers();
+    runCommitSearch("   ", {}, handlers);
+
+    expect(handlers.startTransition).not.toHaveBeenCalled();
+    expect(trackAppEvent).not.toHaveBeenCalled();
+  });
+
+  it("ignores invalid usernames", () => {
+    const { handlers } = createHandlers();
+    runCommitSearch("bad_name", {}, handlers);
+
+    expect(handlers.startTransition).not.toHaveBeenCalled();
+  });
+
+  it("updates the shared URL and tracks a user-sourced search", async () => {
+    vi.mocked(getCommits).mockResolvedValue(foundResult);
+    const { handlers, settle } = createHandlers();
+
+    runCommitSearch("octocat", { updateUrl: true }, handlers);
+    await settle();
+
+    expect(updateSharedSearchUrl).toHaveBeenCalledWith("octocat");
+    expect(handlers.setLastSearchedUsername).toHaveBeenCalledWith("octocat");
+    expect(handlers.setShareStatus).toHaveBeenCalledWith("");
+    expect(handlers.setResult).toHaveBeenCalledWith(foundResult);
+    expect(trackAppEvent).toHaveBeenCalledWith("search_submitted", { source: "user" });
+    expect(trackAppEvent).toHaveBeenCalledWith("search_completed", {
+      found: true,
+      error_kind: "none",
+      commit_count: 1,
+    });
+  });
+
+  it("does not touch the URL for shared-link searches", async () => {
+    vi.mocked(getCommits).mockResolvedValue(foundResult);
+    const { handlers, settle } = createHandlers();
+
+    runCommitSearch("octocat", {}, handlers);
+    await settle();
+
+    expect(updateSharedSearchUrl).not.toHaveBeenCalled();
+    expect(trackAppEvent).toHaveBeenCalledWith("search_submitted", { source: "shared_url" });
+  });
+
+  it("persists successful searches, de-duplicating case-insensitively", async () => {
+    vi.mocked(getCommits).mockResolvedValue(foundResult);
+    const { handlers, settle } = createHandlers();
+
+    runCommitSearch("octocat", {}, handlers);
+    await settle();
+
+    expect(handlers.setRecentSearches).toHaveBeenCalledTimes(1);
+    const updater = handlers.setRecentSearches.mock.calls[0][0] as (prev: string[]) => string[];
+    const next = updater(["OCTOCAT", "torvalds"]);
+
+    expect(next).toEqual(["octocat", "torvalds"]);
+    expect(saveStoredRecentSearches).toHaveBeenCalledWith(["octocat", "torvalds"]);
+  });
+
+  it("does not record recent searches for unsuccessful results", async () => {
+    vi.mocked(getCommits).mockResolvedValue({ found: false, errorKind: "empty", commits: [] });
+    const { handlers, settle } = createHandlers();
+
+    runCommitSearch("octocat", {}, handlers);
+    await settle();
+
+    expect(handlers.setRecentSearches).not.toHaveBeenCalled();
+    expect(trackAppEvent).toHaveBeenCalledWith("search_completed", {
+      found: false,
+      error_kind: "empty",
+      commit_count: 0,
+    });
+  });
+});

--- a/app/home/sharedSearch.test.ts
+++ b/app/home/sharedSearch.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { CommitData, CommitInfo } from "../commitTypes";
+import {
+  buildResultShareText,
+  clearSharedSearchUrl,
+  getInitialSharedUsername,
+  updateSharedSearchUrl,
+} from "./sharedSearch";
+
+const commit: CommitInfo = {
+  message: "Initial commit\n\nLonger body that should not appear in the summary",
+  date: "2020-01-02T03:04:05Z",
+  html_url: "https://github.com/octocat/repo/commit/abc123",
+  sha: "abc123",
+  repository: { name: "repo", owner: "octocat", full_name: "octocat/repo" },
+  author: {
+    login: "octocat",
+    avatar_url: "https://github.com/ghost.png",
+    html_url: "https://github.com/octocat",
+  },
+};
+
+afterEach(() => {
+  window.history.replaceState(null, "", "/");
+});
+
+describe("getInitialSharedUsername", () => {
+  it("reads the user query parameter", () => {
+    window.history.replaceState(null, "", "/?user=octocat");
+    expect(getInitialSharedUsername()).toBe("octocat");
+  });
+
+  it("returns an empty string when the parameter is absent", () => {
+    window.history.replaceState(null, "", "/");
+    expect(getInitialSharedUsername()).toBe("");
+  });
+});
+
+describe("updateSharedSearchUrl and clearSharedSearchUrl", () => {
+  it("adds and removes the user query parameter", () => {
+    updateSharedSearchUrl("torvalds");
+    expect(window.location.search).toBe("?user=torvalds");
+
+    clearSharedSearchUrl();
+    expect(window.location.search).toBe("");
+  });
+
+  it("preserves unrelated query parameters when clearing", () => {
+    window.history.replaceState(null, "", "/?ref=hn&user=gaearon");
+    clearSharedSearchUrl();
+    expect(window.location.search).toBe("?ref=hn");
+  });
+});
+
+describe("buildResultShareText", () => {
+  it("summarizes the first commit using only its subject line", () => {
+    const result: CommitData = { found: true, commits: [commit] };
+    const text = buildResultShareText("octocat", result);
+
+    expect(text).toContain("octocat's first public commit: Initial commit");
+    expect(text).not.toContain("Longer body");
+    expect(text).toContain("Repository: octocat/repo");
+    expect(text).toContain("Commit: https://github.com/octocat/repo/commit/abc123");
+  });
+
+  it("falls back to a search summary when there are no commits", () => {
+    const result: CommitData = { found: false, commits: [] };
+    expect(buildResultShareText("octocat", result)).toContain(
+      "octocat's first public commit search:",
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "web",
+  "name": "my-first-commit",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "web",
+      "name": "my-first-commit",
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "my-first-commit",
   "version": "0.1.0",
   "private": true,
   "engines": {


### PR DESCRIPTION
## What

The 🟢 Low-priority docs & polish group from the code review.

- **`SPEC.md`**: removed copy-paste artifacts (stray box-drawing `│` characters and broken line wrapping) and added a heading. Wording preserved.
- **`package.json`**: renamed the package from the generic `"web"` to `"my-first-commit"`; lockfile synced (diff is just the two `name` fields).
- **Tests**: added direct unit coverage for the pure search-helper modules that were previously only exercised indirectly through the page integration tests:
  - `resultMessages` — error copy per kind, retry eligibility, empty-result detection.
  - `sharedSearch` — shared `?user=` URL read/update/clear and share-text building.
  - `searchExecution` — `runCommitSearch` orchestration, analytics events, and recent-search persistence (incl. case-insensitive de-duplication).

Unit tests: **77 → 104** (+27). No application runtime code changed.

## Tested

- `npm run format:check` — clean
- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 104 passing
- `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)