### PR TITLE
chore(vercel): stop deploying Entire checkpoint branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "entire/checkpoints/v1": false
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a `vercel.json` that disables Git deployments for the `entire/checkpoints/v1` branch.

```json
{
  "git": { "deploymentEnabled": { "entire/checkpoints/v1": false } }
}
```

## Why

The Entire CLI pushes a `entire/checkpoints/v1` branch to `origin` on every checkpoint. Vercel deploys **every** pushed branch, so each `Checkpoint: <sha>` commit triggered a preview build that **failed** and sent a failure email. Real PR commits always succeed; only the checkpoint snapshots fail.

Diagnosis (Preview deployment status vs commit):

| Status | Commit |
|---|---|
| ✅ | `refactor(app): tidy search internals` (PR) |
| ❌ | `Checkpoint: ae596b06…` |
| ✅ | `chore(tooling): add Prettier…` (PR) |
| ❌ | `Checkpoint: 109d83cd…` |

The failures began with PR #57 (Entire setup), exactly when that branch started being pushed.

## Effect

- Checkpoints stay backed up on GitHub, but no longer produce (failing) Vercel deployments → no more failure emails.
- **PR preview** and **production** deployments are unaffected (not listed in the map → default enabled).

## Follow-up

A Vercel dashboard **Ignored Build Step** will be added to glob the whole `entire/*` namespace (future-proofing against a `v2` branch). This PR is the in-repo half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)