### PR TITLE
chore(docs): make AGENTS.md the canonical agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+# GitHub Copilot
+
+Project instructions for this repository live in one canonical file: [AGENTS.md](../AGENTS.md).
+
+Read [AGENTS.md](../AGENTS.md) for commands, layout, gotchas, and conventions.
+
+Do not add project instructions to this file. Anything worth remembering belongs in
+[AGENTS.md](../AGENTS.md) instead. CI runs `npm run check:agent-docs`, which fails if this file
+drifts from the pointer template.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,8 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      - name: Check agent instruction files
+        run: npm run check:agent-docs
+
       - name: Build
         run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# Agent Instructions
+
+Canonical instructions for coding agents working in this repository. `CLAUDE.md`, `GEMINI.md`, and
+`.github/copilot-instructions.md` are pointers to this file and must stay pointers. Add project
+context here, never in the pointer files. CI enforces this with `npm run check:agent-docs`.
+
+## Project
+
+My First Commit is a Next.js 16 App Router app (React 19, Tailwind 4, TypeScript strict). A visitor
+enters a GitHub handle and sees that user's first public commit plus the nine that followed. There
+is no database, no accounts, and no server-side storage of searches.
+
+## Commands
+
+```bash
+npm run dev              # localhost:3000
+npm test                 # vitest run (jsdom)
+npm run test:watch
+npm run lint             # eslint
+npm run format           # prettier --write
+npm run format:check     # prettier --check (CI gate)
+npm run check:agent-docs # verify agent pointer files have not drifted
+npm run build
+npm run test:e2e         # playwright; boots its own dev server on :3100
+```
+
+Full pre-PR validation, matching the `CI / validate` job:
+
+```bash
+npm test && npm run lint && npm run format:check && npm run check:agent-docs && npm run build && npm run test:e2e
+```
+
+## Layout
+
+- `app/page.tsx` — homepage shell
+- `app/actions.ts` — `getCommits` server action; Octokit search plus error normalization
+- `app/commitSearchCache.ts` — in-memory TTL cache (5 minutes, 100 entries)
+- `app/username.ts` — validation and normalization, used on both the client and the server action
+- `app/logger.ts` — structured warn/error logging
+- `app/home/` — homepage search internals (hook, form, results, recent searches, analytics)
+- `app/api/health/route.ts` — runtime health JSON for production checks
+- `components/FirstCommitDisplay.tsx` — result timeline rendering
+- `tests/e2e/` — Playwright specs; unit tests are colocated as `*.test.ts(x)`
+
+## Gotchas
+
+- **E2E mocks.** `E2E_COMMIT_SEARCH_MOCKS=1` makes `app/actions.ts` return fixtures for the reserved
+  usernames `e2e-result`, `e2e-empty`, `e2e-rate-limit`, and `e2e-unavailable`. Playwright sets this
+  automatically and runs the app on port **3100**, not 3000. Add new fixture cases in `app/actions.ts`
+  when adding browser coverage for a new state.
+- **Prettier ignores `*.md`.** Prose is formatted by hand. Do not run the formatter over docs, and do
+  not reflow markdown as part of an unrelated change.
+- **The commit cache is per-process.** It is a plain `Map`, so it resets on every serverless cold
+  start and is not shared between instances. Never treat it as durable storage.
+- **Logging is sanitized on purpose.** `app/logger.ts` takes an event name plus scalar fields. Never
+  log usernames, tokens, or raw Octokit error objects.
+- **`GITHUB_TOKEN` is server-only.** Never expose it as a `NEXT_PUBLIC_*` variable. The app works
+  unauthenticated but hits GitHub search rate limits quickly.
+- **Recent searches live only in the browser**, under `my-first-commit:recent-searches`.
+
+## Conventions
+
+- Node 22 (`.nvmrc`). Import alias `@/*` resolves to the repo root.
+- Branch names: `<your-github-handle>/<type>/<short-description>`.
+- PR titles use Conventional Commits, for example `feat(app): add runtime health endpoint`.
+- One logical change per PR, roughly 400 changed lines or fewer.
+- Add unit tests with the change, plus Playwright coverage for user-visible flows when practical.
+
+## More Detail
+
+- [docs/architecture.md](docs/architecture.md) — request flow, data boundaries, failure handling
+- [docs/development.md](docs/development.md) — setup, env vars, validation, dependency policy
+- [docs/production.md](docs/production.md) — production runbook and troubleshooting
+- [CONTRIBUTING.md](CONTRIBUTING.md) — branch, PR, and review workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude Code
+
+Project instructions for this repository live in one canonical file: [AGENTS.md](AGENTS.md).
+
+Read [AGENTS.md](AGENTS.md) for commands, layout, gotchas, and conventions.
+
+Do not add project instructions to this file. Anything captured with the `#` shortcut during a
+session belongs in [AGENTS.md](AGENTS.md) instead. CI runs `npm run check:agent-docs`, which fails
+if this file drifts from the pointer template.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Thanks for helping improve My First Commit. Keep changes small, tested, and easy
    npm test
    npm run lint
    npm run format:check
+   npm run check:agent-docs
    npm run build
    npm run test:e2e
    ```

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,9 @@
+# Gemini CLI
+
+Project instructions for this repository live in one canonical file: [AGENTS.md](AGENTS.md).
+
+Read [AGENTS.md](AGENTS.md) for commands, layout, gotchas, and conventions.
+
+Do not add project instructions to this file. Anything worth remembering belongs in
+[AGENTS.md](AGENTS.md) instead. CI runs `npm run check:agent-docs`, which fails if this file drifts
+from the pointer template.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The app is intentionally small: no accounts, no database, and no server-side sto
 - **Manual QA checklist:** [docs/manual-qa.md](docs/manual-qa.md)
 - **Release guide:** [docs/release.md](docs/release.md)
 - **Contributing guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Agent instructions:** [AGENTS.md](AGENTS.md)
 - **Roadmap:** [ROADMAP.md](ROADMAP.md)
 - **Changelog:** [CHANGELOG.md](CHANGELOG.md)
 - **Label guide:** [docs/labels.md](docs/labels.md)
@@ -80,6 +81,7 @@ The app is a Next.js App Router project. The browser collects a GitHub username,
 - Use the [manual QA checklist](docs/manual-qa.md) for release and Open Graph preview validation.
 - Use the [release guide](docs/release.md) to cut tags and GitHub releases.
 - Use the [contributing guide](CONTRIBUTING.md) for branch, PR, review, and validation workflow.
+- Use [AGENTS.md](AGENTS.md) for coding agent instructions. It is the single canonical file; `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` are pointers to it, enforced by `npm run check:agent-docs`.
 - Use the [roadmap](ROADMAP.md) to track near-term and deferred ideas.
 - Use the [label guide](docs/labels.md) for issue and pull request labels.
 - Use the [changelog](CHANGELOG.md) to track user-facing changes and release notes.

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,8 +53,16 @@ Run the same core checks used by CI:
 npm audit
 npm test
 npm run lint
+npm run format:check
+npm run check:agent-docs
 npm run build
 ```
+
+`npm run check:agent-docs` keeps [AGENTS.md](../AGENTS.md) the single source of agent instructions.
+`CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` must stay byte-for-byte pointers to
+it, so notes captured by a coding agent (for example Claude Code's `#` shortcut) do not quietly
+accumulate in a tool-specific file. Move the content into `AGENTS.md`, then run
+`npm run check:agent-docs -- --fix` to restore the pointers.
 
 Run the local browser health check:
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "check:agent-docs": "node scripts/check-agent-docs.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",

--- a/scripts/check-agent-docs.mjs
+++ b/scripts/check-agent-docs.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Keeps AGENTS.md the single source of agent instructions.
+//
+// CLAUDE.md, GEMINI.md, and .github/copilot-instructions.md must stay byte-for-byte pointers to
+// AGENTS.md. Claude Code's `#` shortcut appends learnings to CLAUDE.md, which is exactly the drift
+// this guards against: the check fails, and the content moves to AGENTS.md instead.
+//
+// Usage:
+//   node scripts/check-agent-docs.mjs          verify (exit 1 on drift)
+//   node scripts/check-agent-docs.mjs --fix    rewrite the pointer files from the template
+
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CANONICAL_DOC = "AGENTS.md";
+const MIN_CANONICAL_LINES = 20;
+const WRAP_COLUMNS = 100;
+
+const POINTER_DOCS = [
+  {
+    file: "CLAUDE.md",
+    title: "Claude Code",
+    link: "AGENTS.md",
+    note: "Anything captured with the `#` shortcut during a session belongs in",
+  },
+  {
+    file: "GEMINI.md",
+    title: "Gemini CLI",
+    link: "AGENTS.md",
+    note: "Anything worth remembering belongs in",
+  },
+  {
+    file: ".github/copilot-instructions.md",
+    title: "GitHub Copilot",
+    link: "../AGENTS.md",
+    note: "Anything worth remembering belongs in",
+  },
+];
+
+function wrap(text, width) {
+  const lines = [];
+  let current = "";
+
+  for (const word of text.split(" ")) {
+    if (current === "") {
+      current = word;
+    } else if (`${current} ${word}`.length <= width) {
+      current = `${current} ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+
+  if (current !== "") lines.push(current);
+  return lines.join("\n");
+}
+
+function expectedContent({ title, link, note }) {
+  const paragraphs = [
+    `# ${title}`,
+    `Project instructions for this repository live in one canonical file: [${CANONICAL_DOC}](${link}).`,
+    `Read [${CANONICAL_DOC}](${link}) for commands, layout, gotchas, and conventions.`,
+    `Do not add project instructions to this file. ${note} [${CANONICAL_DOC}](${link}) instead. ` +
+      "CI runs `npm run check:agent-docs`, which fails if this file drifts from the pointer template.",
+  ];
+
+  return `${paragraphs.map((paragraph) => wrap(paragraph, WRAP_COLUMNS)).join("\n\n")}\n`;
+}
+
+async function readIfPresent(path) {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function firstDifference(actual, expected) {
+  const actualLines = actual.split("\n");
+  const expectedLines = expected.split("\n");
+
+  for (let index = 0; index < Math.max(actualLines.length, expectedLines.length); index += 1) {
+    if (actualLines[index] !== expectedLines[index]) {
+      return {
+        line: index + 1,
+        actual: actualLines[index] ?? "<end of file>",
+        expected: expectedLines[index] ?? "<end of file>",
+      };
+    }
+  }
+
+  return null;
+}
+
+async function main() {
+  const fix = process.argv.includes("--fix");
+  const problems = [];
+
+  const canonical = await readIfPresent(join(repoRoot, CANONICAL_DOC));
+  if (canonical === null) {
+    problems.push(`${CANONICAL_DOC} is missing. It holds the canonical agent instructions.`);
+  } else if (canonical.trim().split("\n").length < MIN_CANONICAL_LINES) {
+    problems.push(
+      `${CANONICAL_DOC} looks empty or stubbed out. Agent instructions belong there, not in the ` +
+        "pointer files.",
+    );
+  }
+
+  for (const doc of POINTER_DOCS) {
+    const path = join(repoRoot, doc.file);
+    const expected = expectedContent(doc);
+    const actual = await readIfPresent(path);
+
+    if (actual === expected) continue;
+
+    if (fix) {
+      await writeFile(path, expected, "utf8");
+      console.log(`fixed ${doc.file}`);
+      continue;
+    }
+
+    if (actual === null) {
+      problems.push(`${doc.file} is missing.`);
+      continue;
+    }
+
+    const difference = firstDifference(actual, expected);
+    problems.push(
+      `${doc.file} has drifted from the pointer template at line ${difference.line}.\n` +
+        `    expected: ${difference.expected}\n` +
+        `    actual:   ${difference.actual}`,
+    );
+  }
+
+  if (fix) {
+    if (problems.length > 0) {
+      console.error(problems.join("\n\n"));
+      process.exit(1);
+    }
+    console.log("Agent docs are consistent.");
+    return;
+  }
+
+  if (problems.length > 0) {
+    console.error("Agent instruction files are out of sync:\n");
+    console.error(`${problems.join("\n\n")}\n`);
+    console.error(
+      `Move any real instructions into ${CANONICAL_DOC}, then run ` +
+        "`npm run check:agent-docs -- --fix` to restore the pointer files.",
+    );
+    process.exit(1);
+  }
+
+  console.log("Agent docs are consistent.");
+}
+
+await main();


### PR DESCRIPTION
## What changed

The repo had no agent instruction file, so every coding session re-derived the command set and project layout from CI, `CONTRIBUTING.md`, and `docs/`.

- **`AGENTS.md`** (new, canonical) — project summary, commands, module map, gotchas, and conventions. Links out to the existing `docs/` rather than duplicating them.
- **Pointer stubs** — `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` each just point at `AGENTS.md`. Gemini CLI and Copilot CLI also read a root `AGENTS.md` natively; the stubs cover the tool-specific paths too.
- **`scripts/check-agent-docs.mjs`** — generates each stub from one template and compares byte-for-byte. Wired into CI after `format:check`, plus the validation lists in `CONTRIBUTING.md` and `docs/development.md`.

## Why the check

Claude Code's `#` shortcut appends learnings to `CLAUDE.md`. Without a guard, project context slowly accumulates in one tool's file and the others go stale. The check turns that into a CI failure that names the offending line:

```
CLAUDE.md has drifted from the pointer template at line 11.
    expected: <end of file>
    actual:   - Always run npm run build before pushing

Move any real instructions into AGENTS.md, then run
`npm run check:agent-docs -- --fix` to restore the pointer files.
```

It also fails if `AGENTS.md` goes missing or drops below 20 lines. `--fix` rewrites the stubs.

## Gotchas captured in AGENTS.md

Found by reading code rather than docs:

- `E2E_COMMIT_SEARCH_MOCKS=1` activates the reserved fixture usernames in `app/actions.ts` (`e2e-result`, `e2e-empty`, `e2e-rate-limit`, `e2e-unavailable`); Playwright runs on port 3100.
- Prettier ignores `*.md` — prose is hand-formatted.
- The commit search cache is a per-process `Map`; it resets on cold start.
- `app/logger.ts` takes sanitized fields only — never usernames, tokens, or raw Octokit errors.

## How it was tested

- `npm run check:agent-docs` passes; verified drift detection by appending a line to `CLAUDE.md` (fails, exit 1) and `--fix` (restores byte-identical).
- `npm run lint`, `npm run format:check`, and `npm run build` pass.
- `npm test` could not be verified locally: this machine runs Node 26 and the project pins Node 22, and `app/page.test.tsx` fails on `window.localStorage` being undefined under jsdom there. The same 36 failures occur on a clean checkout of `main`, so they are environmental and unrelated to this change. CI runs Node 22 via `.nvmrc` and is the real signal.

No app code is touched — docs, one standalone Node script, one npm script, one CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)