### PR TITLE
chore(entire): stop Vercel deploying the Entire checkpoint branch

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,4 +1,9 @@
 {
   "enabled": true,
-  "telemetry": false
+  "telemetry": false,
+  "checkpoints": {
+    "primary": {
+      "type": "git-refs"
+    }
+  }
 }

--- a/docs/production.md
+++ b/docs/production.md
@@ -248,6 +248,36 @@ Check logs for `github_commit_search_malformed_item`. The app skips malformed re
 
 Preview deployments may not have all production environment variables. Check Vercel project environment variable scope and branch/preview settings.
 
+### Vercel Builds A Branch That Has No App Code
+
+Vercel creates a deployment for every branch push. A branch whose tree has no `package.json` fails at
+the install step with `ENOENT ... /vercel/path0/package.json`.
+
+This happened with Entire's checkpoint storage. Entire used to push `entire/checkpoints/v1`, a branch
+holding only its object store, on every `git push`, and each push produced a failed preview
+deployment.
+
+Do not try to fix this with `vercel.json`. Vercel reads `vercel.json` from the commit being deployed,
+so `git.deploymentEnabled` and `ignoreCommand` are never consulted for a branch that does not contain
+the file. That is exactly the branch class the setting appears to target, which makes the fix look
+correct while doing nothing.
+
+Fix it at the source instead, so no branch is pushed:
+
+```bash
+entire configure --checkpoint-backend refs
+```
+
+Checkpoints then land under `refs/entire/checkpoints/*` rather than `refs/heads/*`, and Vercel has no
+branch to deploy. The old `entire/checkpoints/v1` branch can stay; it is simply no longer pushed to.
+
+Verify from the GitHub side without Vercel access:
+
+```bash
+git ls-remote origin 'refs/*' | grep entire   # checkpoints should be outside refs/heads/
+gh api "repos/<owner>/<repo>/deployments?per_page=10" --jq '.[] | "\(.id) \(.environment) \(.ref)"'
+```
+
 ## Dependency Updates
 
 Dependabot opens minor and patch dependency PRs. Major version upgrades are intentionally ignored by Dependabot and should be handled as planned compatibility work.

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "git": {
-    "deploymentEnabled": {
-      "entire/checkpoints/v1": false
-    }
-  }
-}


### PR DESCRIPTION
## The failure

Vercel had **10 failed deployments** in the last 100 — every one of them the `entire/checkpoints/v1` branch. Zero on `main` or PR branches; production has been healthy throughout.

Entire pushed that branch on every `git push`. Vercel creates a deployment for any branch push, cloned it, and found no app code:

```
Cloning github.com/scottdensmore/my-first-commit (Branch: entire/checkpoints/v1, Commit: 9980bc8)
Running "install" command: `npm install`...
npm error enoent Could not read package.json: ENOENT ... /vercel/path0/package.json
Error: Command "npm install" exited with 254
```

The branch holds only Entire's object store (`04`, `10`, `21`, …) — no `package.json`, no `vercel.json`.

## Why #62 could not have worked

#62 added `git.deploymentEnabled: {"entire/checkpoints/v1": false}` to `vercel.json`. Vercel reads `vercel.json` **from the commit being deployed**, and the checkpoint branch has no `vercel.json` — so the setting was never consulted. The build log above is from *after* #62 merged, and it reaches `Running "vercel build"`, which independently confirms the config was never applied.

This is structural, not a typo: the mechanism cannot suppress precisely the branch class it appears to target. `ignoreCommand` fails for the same reason. Vercel's dashboard-side Ignored Build Step no longer exists in the current UI.

## The fix

Remove the trigger at the source — `entire configure --checkpoint-backend refs`:

```json
"checkpoints": { "primary": { "type": "git-refs" } }
```

| | Before | After |
|---|---|---|
| Push hook | `Pushing entire/checkpoints/v1 to origin` | `Pushing 1 checkpoint ref(s) to origin` |
| Checkpoint ref | `refs/heads/entire/checkpoints/v1` | `refs/entire/checkpoints/SY/01KYXM77NB…` |
| Vercel sees a branch | yes → builds → fails | no |

Checkpoints now live outside `refs/heads/*`, so Vercel has no branch to deploy. The old branch is left untouched at `9980bc8` — history preserved, just no longer pushed to.

Also removes `vercel.json`, whose only content was the inert block. It documented an intent it could not enforce, which is worse than absent. The failure mode and the fix are recorded in `docs/production.md` so the `vercel.json` approach does not get re-added.

## How it was verified

Pushed this branch and observed live:

- Checkpoint landed at `refs/entire/checkpoints/SY/01KYXM77NB…`, outside `refs/heads/`.
- `refs/heads/entire/checkpoints/v1` unchanged at `9980bc8` — no longer receiving pushes.
- **No checkpoint deployment created.**
- Preview deployment `5701088262` for this branch: **success** — normal previews still work.

`npm run check:agent-docs`, `npm run lint`, and `npm run format:check` pass. No app code touched.

## Note

Entire also creates a local branch `entire/<sha>-<hash>` under `refs/heads/entire/`. It is not pushed to origin, so it is currently harmless, but it is worth watching — if anything ever pushes it, Vercel would try to deploy it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)