### PR TITLE
ci(release): skip promotion for superseded production deployments

### DIFF
--- a/.github/workflows/promote-production-release.yml
+++ b/.github/workflows/promote-production-release.yml
@@ -29,8 +29,39 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      # Two production deployments landing close together queue two promotions. The older one runs
+      # after main has already advanced, and pushing its tag is rejected when the deployed commit's
+      # workflow files no longer match main:
+      #   refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml`
+      #   without `workflows` permission
+      # The superseded commit is no longer production, so skip it instead of failing the run. The
+      # newer commit gets its own promotion.
+      - name: Skip superseded deployment
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Resolved through the API rather than git, because the checkout above is shallow and
+          # pinned to the deployed commit, so origin/main is not necessarily present locally.
+          tip="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
+
+          if [ -z "$tip" ]; then
+            echo "Could not resolve the current main tip."
+            exit 1
+          fi
+
+          if [ "$tip" != "$TARGET_SHA" ]; then
+            echo "main has advanced to ${tip}."
+            echo "${TARGET_SHA} is no longer the deployed production commit; skipping its release."
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "superseded=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve release tag
         id: release
+        if: steps.guard.outputs.superseded != 'true'
         run: |
           version="$(node -p "require('./package.json').version")"
           short_sha="$(printf '%s' "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)"
@@ -40,6 +71,7 @@ jobs:
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
 
       - name: Confirm CI passed for deployed commit
+        if: steps.guard.outputs.superseded != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -55,6 +87,7 @@ jobs:
           fi
 
       - name: Create tag and GitHub release
+        if: steps.guard.outputs.superseded != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
## The failure

`6f1917d` passed CI and the production health check but never got a tag or release. Its promotion run failed at the tag push:

```
! [remote rejected] v0.1.0-6f1917d -> v0.1.0-6f1917d (refusing to allow a GitHub App to
  create or update workflow `.github/workflows/ci.yml` without `workflows` permission)
```

Two production deployments landed seconds apart (#71 then #67), queueing two promotions. By the time the older one ran, `main` had already advanced — so it was tagging a commit whose workflow files no longer matched `main`, and `GITHUB_TOKEN` cannot push that.

The release for `6f1917d` has since been backfilled manually.

## What I verified, and what I did not

Confirmed from the run logs:

| commit | workflow files touched | was tip when promoted | tag |
|---|---|---|---|
| `fbfdbd7` | 0 | yes | created |
| `6f1917d` | 2 | **no** | **rejected** |
| `0d52aab` | 4 | yes | created |
| `dc638b4` | 0 | yes | created |

`0d52aab` touched four workflow files and pushed fine (`* [new tag] v0.1.0-0d52aab`), so "commit touches workflow files" is **not** the trigger on its own. Being superseded is what the failing case has that the others don't.

I have **not** proven the exact rule GitHub applies. This PR does not depend on knowing it: it removes the race that produced the condition.

## The change

A guard step after checkout compares the deployed commit against the current `main` tip. If `main` has moved on, the promotion skips cleanly instead of failing — the newer commit gets its own promotion, so nothing is lost.

- The tip is resolved via `gh api`, not git: the checkout is shallow and pinned to the deployed commit, so `origin/main` is not reliably present locally.
- If the tip cannot be resolved at all, the step **fails loudly** rather than silently skipping.
- A genuinely broken promotion for a current commit still fails, as before.

## How it was tested

YAML parses and every step carries the expected guard. The branching logic was exercised directly:

```
tip == target (current)      → superseded=false
tip != target (superseded)   → superseded=true
empty tip                    → exit 1
```

The end-to-end path only runs on `workflow_run` after a real production health check, so it cannot be exercised from a PR. First merge to `main` after this exercises the `superseded=false` path.

## Separate issue, not fixed here

Pushing a `v*.*.*` tag also triggers `release.yml`, which creates a GitHub release from the changelog — while `promote-production-release.yml` creates one from deployment metadata. Both target the same tag and race; the promote script's "Release $TAG already exists" branch exists because of it. I hit this during the backfill: `release.yml` won, producing a release with the wrong body that also stole the "Latest" pointer. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)