### PR TITLE
ci(release): stop Release and Promote racing on deployment tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,12 @@ name: Release
 on:
   push:
     tags:
+      # Semantic release tags only. Deployment tags (vX.Y.Z-<sha>) are owned by
+      # promote-production-release.yml, which creates their release with deployment metadata. Both
+      # workflows firing on the same tag raced to call `gh release create`, and the loser's notes
+      # were silently discarded. The negative pattern must stay after the positive one.
       - "v*.*.*"
+      - "!v*.*.*-*"
   workflow_dispatch:
     inputs:
       tag:
@@ -46,20 +51,41 @@ jobs:
           fi
 
           version="${tag#v}"
-          base_version="${version%%-*}"
+
+          if printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}$'; then
+            deployment=true
+          else
+            deployment=false
+          fi
+
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "base_version=$base_version" >> "$GITHUB_OUTPUT"
+          echo "deployment=$deployment" >> "$GITHUB_OUTPUT"
 
       - name: Extract changelog notes
         id: notes
         env:
           VERSION: ${{ steps.release.outputs.version }}
-          BASE_VERSION: ${{ steps.release.outputs.base_version }}
+          DEPLOYMENT: ${{ steps.release.outputs.deployment }}
           TAG: ${{ steps.release.outputs.tag }}
         run: |
-          awk -v version="$VERSION" -v base_version="$BASE_VERSION" '
-            $0 ~ "^## " version "($| )" || $0 ~ "^## " base_version "($| )" {
+          # A deployment tag only reaches this workflow through a manual dispatch, because
+          # promote-production-release.yml normally publishes it. Its notes describe the deployment,
+          # not a version's changelog. Matching the base version here used to pull in the whole
+          # vX.Y.Z changelog section, which is not what a per-deployment release should say.
+          if [ "$DEPLOYMENT" = "true" ]; then
+            {
+              echo "Production deployment release for $TAG."
+              echo
+              echo "This release was published manually for a deployment that was already healthy."
+              echo
+              echo "See the commit history for the exact changes included in this deployment."
+            } > release-notes.md
+            exit 0
+          fi
+
+          awk -v version="$VERSION" '
+            $0 ~ "^## " version "($| )" {
               capture = 1
               next
             }
@@ -71,15 +97,7 @@ jobs:
             }
           ' CHANGELOG.md > release-notes.md
 
-          if [ ! -s release-notes.md ] && printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}$'; then
-            {
-              echo "Production deployment release for $TAG."
-              echo
-              echo "This release was created automatically after Vercel deployed the commit and the Production Health Check passed."
-              echo
-              echo "See the commit history for the exact changes included in this deployment."
-            } > release-notes.md
-          elif [ ! -s release-notes.md ]; then
+          if [ ! -s release-notes.md ]; then
             echo "No CHANGELOG.md section found for $VERSION."
             echo "Add a '## $VERSION' section before publishing."
             exit 1

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,7 +45,21 @@ The release workflow requires a `CHANGELOG.md` section named for the tag without
 ## 0.2.0
 ```
 
-Automatic deployment release tags can use generated release notes when a matching changelog section does not exist.
+## Which Workflow Owns Which Tag
+
+The two release workflows own different tag shapes and must not both publish the same tag:
+
+| Tag | Owner | Notes come from |
+| --- | --- | --- |
+| `vX.Y.Z` | `Release` | the matching `CHANGELOG.md` section |
+| `vX.Y.Z-<deployed-short-sha>` | `Promote Production Release` | deployment metadata |
+
+`Release` ignores deployment tags on push. Both workflows used to fire on `vX.Y.Z-<sha>` and race to
+call `gh release create`; the loser's notes were discarded, so a deployment release could end up
+carrying the `vX.Y.Z` changelog instead of its deployment metadata.
+
+To publish a deployment tag by hand, for example when an automatic promotion was skipped, run
+`Release` manually with the tag as input. It produces deployment notes rather than changelog notes.
 
 ## After Release
 


### PR DESCRIPTION
## The problem

`release.yml` fires on `v*.*.*`, which **also matches deployment tags** like `v0.1.0-6f1917d`. So both it and `promote-production-release.yml` published the same tag and raced to call `gh release create`. That is why the promote script carries a `"Release $TAG already exists."` branch.

Promote usually won, so every existing deployment release has the right body:

```
v0.1.0-dc638b4 → "Production deployment release for v0.1.0-dc638b4."
v0.1.0-0d52aab → "Production deployment release for v0.1.0-0d52aab."
v0.1.0-a803f6d → "Production deployment release for v0.1.0-a803f6d."
v0.1.0-3b56d4b → "Production deployment release for v0.1.0-3b56d4b."
```

When `release.yml` won, the body was wrong. Its changelog extraction matched on `base_version`, so `0.1.0-6f1917d` matched `## 0.1.0` and pulled in the entire 0.1.0 changelog. The deployment-notes fallback only ran if the changelog lookup came up **empty**, which it essentially never did — the fallback was unreachable in practice.

This surfaced while backfilling `v0.1.0-6f1917d`. With no promote run racing it, `release.yml` published that release with the 0.1.0 changelog as its body and took the **"Latest"** pointer from `dc638b4`, the actual production commit. Both were corrected by hand.

## The change

Each workflow gets one tag shape:

| Tag | Owner | Notes from |
| --- | --- | --- |
| `vX.Y.Z` | `Release` | matching `CHANGELOG.md` section |
| `vX.Y.Z-<sha>` | `Promote Production Release` | deployment metadata |

- `release.yml` excludes deployment tags on push via `"!v*.*.*-*"` (negative pattern must follow the positive one).
- Manual `workflow_dispatch` on a deployment tag still works — that is the backfill escape hatch — but now writes deployment notes instead of matching the base version.
- `base_version` is gone; it existed only for the matching that caused the bug.
- `docs/release.md` documents the ownership split, replacing a line that described the old behavior.

## How it was tested

Tag filter evaluated with `fnmatch`, exactly as Actions applies these globs:

```
v0.1.0           → RUNS release.yml
v1.2.3           → RUNS release.yml
v0.1.0-6f1917d   → excluded
v0.2.0-abcdef1   → excluded
```

Deployment detection:

```
v0.1.0                → deployment=false
v0.1.0-6f1917d        → deployment=true
v1.2.3                → deployment=false
v0.1.0-abcdef1234567  → deployment=true
```

Changelog extraction still returns the `## 0.1.0` section for a semantic tag. Both workflow files parse as valid YAML; `check:agent-docs` and `format:check` pass.

The push path can only be exercised by pushing a real tag, so it is not covered by PR CI.

## Note

`promote-production-release.yml` keeps its `"Release $TAG already exists."` branch. It is no longer load-bearing for the race, but still guards re-runs of the same promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)