### PR TITLE
chore(release): prepare the 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ## Unreleased
 
+## 0.2.0 - 2026-08-01
+
 ### Added
 
 - Canonical `AGENTS.md` agent instructions, with `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` reduced to pointer files that CI keeps in sync through `npm run check:agent-docs`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-first-commit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-first-commit",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-first-commit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "engines": {
     "node": "22.x"


### PR DESCRIPTION
Cuts the first version release since `0.1.0` (2026-05-11). Thirteen changelog bullets have accumulated in `Unreleased` since then.

## What changed

- `CHANGELOG.md`: `Unreleased` entries moved into a dated `## 0.2.0 - 2026-08-01` section, leaving an empty `Unreleased` ready for the next change, per `docs/release.md`.
- `package.json` / `package-lock.json`: version bumped to `0.2.0`.

No application code changes.

## Why this release matters beyond the version number

`release.yml`'s semantic-tag path has not run since #80 rewrote it. That PR removed `base_version`, changed the changelog extraction, and added the `!v*.*.*-*` filter so `Release` and `Promote Production Release` no longer race for the same tag. Only the deployment-tag half of that change has been exercised in production. Tagging `v0.2.0` runs the other half for the first time.

I simulated the workflow's `awk` extraction against the new section locally: it captures all four subsections (Added / Fixed / Changed / Security) and stops cleanly before `## 0.1.0`.

## Side effect worth noting

`Promote Production Release` derives its tag from `package.json`, so deployment tags become `v0.2.0-<sha>` once this merges. The footer release link follows the same version.

## Validation

| Check | Result |
| --- | --- |
| `npm audit` | 0 vulnerabilities |
| `npm run format:check` | pass |
| `npm run check:agent-docs` | pass |
| `npm run lint` | pass |
| `npm run build` | pass |
| `npm test` | not run locally |

`npm test` fails on this machine with `window.localStorage` undefined under jsdom — a pre-existing environment mismatch (local Node 26 vs the pinned Node 22), unrelated to this change. CI on Node 22 is the signal. No test references the package version, so the bump cannot affect them.

## After merge

Tag `v0.2.0` on the merge commit and push it, which triggers `Release` to publish the GitHub release using the `0.2.0` changelog section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)