### PR TITLE
ci(release): keep the Latest pointer on version releases

### DIFF
--- a/.github/workflows/promote-production-release.yml
+++ b/.github/workflows/promote-production-release.yml
@@ -115,8 +115,13 @@ jobs:
             echo "- Production health check: $RUN_URL"
           } > release-notes.md
 
+          # --latest=false is required. Without it the "Latest" pointer is chosen automatically from
+          # date and version, and a fresh deployment tag always wins against the vX.Y.Z release it
+          # was deployed from. A deployment tag is a deployment record, not the current version, so
+          # /releases/latest must keep pointing at the version release.
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file release-notes.md \
             --target "$TARGET_SHA" \
+            --latest=false \
             --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,4 +107,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}
-        run: gh release create "$TAG" --title "$TAG" --notes-file release-notes.md --verify-tag
+          DEPLOYMENT: ${{ steps.release.outputs.deployment }}
+        run: |
+          # Set the "Latest" pointer explicitly in both directions. The default is chosen from date
+          # and version, which makes it depend on publish order rather than intent. A version release
+          # owns "Latest"; a deployment tag published here by manual dispatch must not take it.
+          if [ "$DEPLOYMENT" = "true" ]; then
+            latest=false
+          else
+            latest=true
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            --latest="$latest" \
+            --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ## Unreleased
 
+### Fixed
+
+- Deployment releases no longer take the "Latest" pointer from the version release they were deployed from. Both release workflows now set it explicitly, so `releases/latest` resolves to the current version instead of the most recent deployment.
+
 ## 0.2.0 - 2026-08-01
 
 ### Added

--- a/docs/release.md
+++ b/docs/release.md
@@ -49,10 +49,18 @@ The release workflow requires a `CHANGELOG.md` section named for the tag without
 
 The two release workflows own different tag shapes and must not both publish the same tag:
 
-| Tag | Owner | Notes come from |
-| --- | --- | --- |
-| `vX.Y.Z` | `Release` | the matching `CHANGELOG.md` section |
-| `vX.Y.Z-<deployed-short-sha>` | `Promote Production Release` | deployment metadata |
+| Tag | Owner | Notes come from | Marked "Latest" |
+| --- | --- | --- | --- |
+| `vX.Y.Z` | `Release` | the matching `CHANGELOG.md` section | yes |
+| `vX.Y.Z-<deployed-short-sha>` | `Promote Production Release` | deployment metadata | no |
+
+Only version releases are marked "Latest". Deployment tags are deployment records, so
+`https://github.com/scottdensmore/my-first-commit/releases/latest` keeps resolving to the current
+version rather than to whichever commit deployed most recently.
+
+Both workflows pass `--latest` explicitly. GitHub otherwise picks the pointer automatically from date
+and version, and a newly published deployment tag takes "Latest" away from the version release it was
+deployed from.
 
 `Release` ignores deployment tags on push. Both workflows used to fire on `vX.Y.Z-<sha>` and race to
 call `gh release create`; the loser's notes were discarded, so a deployment release could end up


### PR DESCRIPTION
## The bug

Publishing `v0.2.0` and then deploying its merge commit moved `releases/latest` from `v0.2.0` to `v0.2.0-0f42315` about a minute later. The deployment record displaced the version release.

Neither workflow passed `--latest`, so GitHub chose the pointer automatically from date and version. A deployment tag is published *after* the version release it came from, so it always wins that comparison. This recurs on **every merge to `main`**, not just this release.

It also isn't new. The same thing happened earlier with the backfilled `v0.1.0-6f1917d` tag. That was corrected by hand and read as a one-off caused by the manual backfill; it was actually the workflow's default behavior, and it reproduced automatically as soon as a version release existed to displace.

## The fix

Set the flag explicitly in **both** directions rather than only opting deployment tags out. `gh release create --latest` defaults to "automatic based on date and version", so leaving either side implicit makes the pointer depend on publish order rather than intent.

- `promote-production-release.yml` always passes `--latest=false`.
- `release.yml` passes `--latest=false` for a deployment tag published through manual dispatch, and `--latest=true` for a version tag.

`release.yml` needed the same treatment because `docs/release.md` documents manual dispatch as the supported way to publish a skipped promotion — that path had the identical hole.

## Docs

The tag-ownership table in `docs/release.md` gains a "Marked Latest" column, plus a note on why the flag is explicit.

| Tag | Owner | Notes come from | Marked "Latest" |
| --- | --- | --- | --- |
| `vX.Y.Z` | `Release` | the matching `CHANGELOG.md` section | yes |
| `vX.Y.Z-<deployed-short-sha>` | `Promote Production Release` | deployment metadata | no |

## Validation

Both workflow files parse as YAML. The branch condition was exercised for `DEPLOYMENT` = `true` / `false` / empty, yielding `--latest=false` / `true` / `true` — an unset value falls back to treating the tag as a version release. `npm run format:check` and `npm run check:agent-docs` pass.

The real proof is the next merge to `main`: `v0.2.0` must still hold "Latest" after its deployment tag is created. I'll verify that after this merges.

Already-published releases were corrected by hand, so `releases/latest` currently resolves to `v0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)