### PR TITLE
ci(release): wait for CI instead of failing a promotion early

### DIFF
--- a/.github/workflows/promote-production-release.yml
+++ b/.github/workflows/promote-production-release.yml
@@ -76,15 +76,49 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          ci_conclusion="$(
-            gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${TARGET_SHA}&branch=main&event=push&status=completed&per_page=10" \
-              --jq '.workflow_runs[0].conclusion // ""'
-          )"
+          # Vercel can deploy, and the health check can pass, before CI finishes on main. This query
+          # used to filter on status=completed, which made "CI is still running" look identical to
+          # "CI does not exist" — both returned an empty list and the step failed. A promotion was
+          # lost that way after checking 8 seconds before CI concluded.
+          #
+          # Poll for a conclusion instead of taking a single snapshot. A missing run stays a failure,
+          # but an unfinished one is simply not an answer yet.
+          deadline=$(( SECONDS + 900 ))
+          ci_conclusion=""
+
+          while :; do
+            ci_run="$(
+              gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${TARGET_SHA}&branch=main&event=push&per_page=10" \
+                --jq '(.workflow_runs[0] // {}) | "\(.status // "") \(.conclusion // "")"' || true
+            )"
+            ci_status="${ci_run%% *}"
+            ci_conclusion="${ci_run#* }"
+
+            if [ "$ci_status" = "completed" ]; then
+              break
+            fi
+
+            if [ -z "$ci_status" ]; then
+              echo "No CI run found yet for ${TARGET_SHA}."
+            else
+              echo "CI run for ${TARGET_SHA} is ${ci_status}; waiting for it to finish."
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Timed out after 15 minutes waiting for CI to finish for ${TARGET_SHA}."
+              echo "Last observed status: '${ci_status:-none}'."
+              exit 1
+            fi
+
+            sleep 15
+          done
 
           if [ "$ci_conclusion" != "success" ]; then
             echo "Expected successful CI run for ${TARGET_SHA}, got '${ci_conclusion:-none}'."
             exit 1
           fi
+
+          echo "CI succeeded for ${TARGET_SHA}."
 
       - name: Create tag and GitHub release
         if: steps.guard.outputs.superseded != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 ### Fixed
 
 - Deployment releases no longer take the "Latest" pointer from the version release they were deployed from. Both release workflows now set it explicitly, so `releases/latest` resolves to the current version instead of the most recent deployment.
+- Release promotion no longer fails when a deployment and its health check finish before CI concludes on `main`. The promotion now waits for the deployed commit's CI run to reach a conclusion instead of treating an unfinished run as a missing one.
 
 ## 0.2.0 - 2026-08-01
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -68,6 +68,19 @@ without `workflows` permission
 
 A promotion that fails for any other reason is a real failure and should be investigated.
 
+### Promotion Waits For CI
+
+Vercel deploys in parallel with `CI / validate`, so a deployment and its health check can finish
+before CI concludes on `main`. The promotion waits up to 15 minutes for the deployed commit's CI run
+to reach a conclusion, logging one line per poll:
+
+```text
+CI run for <sha> is in_progress; waiting for it to finish.
+```
+
+Waiting is normal. A promotion fails only when CI concludes with something other than success, or
+when no CI run reaches a conclusion inside the timeout.
+
 ## Release Checklist
 
 Use this checklist before treating a `main` merge as a healthy release:


### PR DESCRIPTION
## The bug

The promotion for `1b94b14` failed:

```
Expected successful CI run for 1b94b146ed4dd182eba337c8eabcca9bb97f235d, got 'none'.
```

CI had not failed. It had not finished.

| Event | Time |
| --- | --- |
| CI for `1b94b14` started | 01:00:42 |
| **Promotion checked for CI** | **01:02:20** |
| CI completed, `success` | 01:02:28 |

Eight seconds early.

## Root cause

The query filtered on `status=completed`:

```
.../ci.yml/runs?head_sha=${TARGET_SHA}&branch=main&event=push&status=completed&per_page=10
```

That makes "CI is still running" and "CI does not exist" indistinguishable — both return an empty list, and the step treats empty as failure. The workflow assumed CI finishes before the deploy → health-check → promote chain, but Vercel deploys in parallel with CI and nothing enforces that ordering. This has been latent since the workflow was written; it just needed the deploy chain to win the race once.

The visible symptom is a production commit that silently never gets its deployment tag or release.

## The fix

Drop the `status=completed` filter, read `status` and `conclusion` from the run, and poll for up to 15 minutes until it concludes. A missing run is still a failure once the timeout expires; an unfinished run is no longer mistaken for one.

Each poll logs a line, so a waiting promotion is legible in the run output rather than looking hung.

## Validation

The jq expression and the loop were exercised against every state, using a stubbed API:

| CI state | Behavior |
| --- | --- |
| `completed` / `success` | proceeds, exit 0 |
| `completed` / `failure` | fails with the conclusion named |
| `queued`, then `in_progress`, then success | waits, then proceeds |
| absent, appears on a later poll | waits, then proceeds |
| absent for the whole window | times out, exit 1 |

`(.workflow_runs[0] // {})` guards the empty-array case, which otherwise renders `null` into the interpolated string. The step's shell also passes `bash -n`, and the file parses as YAML.

## Verification after merge

This merge exercises the fix on itself: its own promotion runs through the new code. But the race only reproduces when the deploy chain beats CI, which is timing-dependent — a green promotion here confirms no regression, not that the race is fixed. The stubbed-state coverage above is the real evidence.

Note the previous failed promotion was recovered by re-running the job after CI finished, which produced `v0.2.0-1b94b14` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)