### PR TITLE
feat(health): report whether GITHUB_TOKEN is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ## Unreleased
 
+### Added
+
+- `/api/health` now reports whether `GITHUB_TOKEN` is configured, so a rotation that never reached the running deployment is visible without a live search. Presence only is reported, never the value. The production health check asserts it against deployed targets.
+
 ### Fixed
 
 - Deployment releases no longer take the "Latest" pointer from the version release they were deployed from. Both release workflows now set it explicitly, so `releases/latest` resolves to the current version instead of the most recent deployment.

--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -32,16 +32,56 @@ describe("GET /api/health", () => {
           configured: true,
           value: "https://my-first-commit-eta.vercel.app",
         },
+        githubToken: {
+          configured: true,
+        },
       },
     });
     expect(body.runtime).toBeUndefined();
     expect(Date.parse(body.timestamp)).not.toBeNaN();
     expect(JSON.stringify(body)).not.toContain("secret-token");
+    // The token check must report presence and nothing else. A value, prefix, length, or hash on a
+    // public endpoint would leak more than "it is set".
+    expect(Object.keys(body.checks.githubToken)).toEqual(["configured"]);
+  });
+
+  it("reports a missing GitHub token without failing health", async () => {
+    process.env = {
+      ...originalEnv,
+      GITHUB_TOKEN: "",
+      NEXT_PUBLIC_SITE_URL: "https://my-first-commit-eta.vercel.app",
+    };
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "ok",
+      checks: {
+        githubToken: {
+          configured: false,
+        },
+      },
+    });
+  });
+
+  it("treats a whitespace-only GitHub token as missing", async () => {
+    process.env = {
+      ...originalEnv,
+      GITHUB_TOKEN: "   ",
+    };
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.checks.githubToken.configured).toBe(false);
   });
 
   it("reports missing optional public configuration without failing health", async () => {
     process.env = {
       ...originalEnv,
+      GITHUB_TOKEN: "",
       NEXT_PUBLIC_SITE_URL: "",
       VERCEL_ENV: "",
       VERCEL_GIT_COMMIT_SHA: "",

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -12,11 +12,21 @@ type HealthPayload = {
       configured: boolean;
       value: string | null;
     };
+    // Deliberately has no `value`, unlike siteUrl. NEXT_PUBLIC_SITE_URL is public by definition,
+    // but GITHUB_TOKEN is a server-side secret, so only its presence is reported. Do not add the
+    // value, a prefix, a length, or a hash here: this endpoint is public and uncached.
+    githubToken: {
+      configured: boolean;
+    };
   };
 };
 
 function getPublicSiteUrl() {
   return process.env.NEXT_PUBLIC_SITE_URL?.trim() || null;
+}
+
+function hasGitHubToken() {
+  return Boolean(process.env.GITHUB_TOKEN?.trim());
 }
 
 function getShortCommit() {
@@ -38,6 +48,9 @@ export function buildHealthPayload(now = new Date()): HealthPayload {
       siteUrl: {
         configured: Boolean(siteUrl),
         value: siteUrl,
+      },
+      githubToken: {
+        configured: hasGitHubToken(),
       },
     },
   };

--- a/docs/production.md
+++ b/docs/production.md
@@ -15,7 +15,9 @@ The app also exposes a lightweight runtime health endpoint:
 https://my-first-commit-eta.vercel.app/api/health
 ```
 
-It returns JSON status, deployment metadata, and whether the public site URL is configured. It does not expose server-side secrets or detailed runtime versions.
+It returns JSON status, deployment metadata, and whether the public site URL and `GITHUB_TOKEN` are configured. It does not expose server-side secrets or detailed runtime versions.
+
+`checks.githubToken` reports presence only, never the value, a prefix, a length, or a hash. The endpoint is public and uncached, so nothing beyond a boolean belongs there. It confirms the variable is set; it does not prove the token is valid or unexpired.
 
 ## Required Configuration
 
@@ -33,6 +35,27 @@ PRODUCTION_BASE_URL=https://my-first-commit-eta.vercel.app
 ```
 
 `GITHUB_TOKEN` is server-side only. Do not expose it as a public `NEXT_PUBLIC_*` variable.
+
+### Rotating `GITHUB_TOKEN`
+
+Vercel applies environment variable changes to new builds only, so a rotation does nothing until the
+project is redeployed.
+
+1. Add the new token in Vercel before revoking the old one, so production never falls back to
+   unauthenticated requests at 60 requests per hour.
+2. Redeploy production.
+3. Confirm the variable reached the running deployment:
+
+   ```bash
+   curl -s https://my-first-commit-eta.vercel.app/api/health | grep -o '"githubToken":{"configured":[a-z]*}'
+   ```
+
+4. Run a search on the public app. `configured: true` only proves the variable is set; a search is
+   what proves the token is accepted by GitHub.
+5. Revoke the old token.
+
+The app only reads public commit search data, so the token needs no scopes. An unscoped classic token
+still raises the Search API limit from 60 to 5,000 requests per hour.
 
 ## Deployment Flow
 
@@ -263,6 +286,16 @@ Open the health check target URL and confirm it renders the public app. If it sh
 Check logs for `github_commit_search_rate_limited`.
 
 Confirm `GITHUB_TOKEN` is set in Vercel production. Unauthenticated GitHub Search API requests have a much lower rate limit.
+
+Check whether the running deployment sees it:
+
+```bash
+curl -s https://my-first-commit-eta.vercel.app/api/health
+```
+
+`checks.githubToken.configured: false` means the variable is missing from the deployment, usually
+because it was changed without redeploying. `true` with rate limiting means the token is set but
+expired, revoked, or genuinely over its limit.
 
 ### GitHub Searches Fail With Validation Errors
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -257,9 +257,20 @@ test("health endpoint reports app status without caching", async ({ request }) =
       siteUrl: {
         configured: expect.any(Boolean),
       },
+      githubToken: {
+        configured: expect.any(Boolean),
+      },
     },
   });
   expect(Date.parse(body.timestamp)).not.toBeNaN();
+
+  // Against a deployed target this is the check that catches a botched token rotation. Locally the
+  // token is optional, so only its shape is asserted above.
+  if (isDeployedTarget) {
+    expect(body.checks.githubToken.configured).toBe(true);
+  }
+
+  expect(JSON.stringify(body)).not.toMatch(/gh[pousr]_/);
 });
 
 test.describe("local mocked commit search states", () => {


### PR DESCRIPTION
## Why

A token rotation could not be verified from outside the Vercel dashboard.

`/api/health` reported only `siteUrl`, and nothing automated exercises a live GitHub search — the commit-search e2e states are mocked and `test.skip`ped against deployed targets (`tests/e2e/home.spec.ts:266`). So `Production Health Check` passes whether the token is valid, expired, or absent.

That matters because Vercel applies environment variable changes to **new builds only**. A rotation saved but not redeployed leaves production running the old value, and until now that looked identical to a healthy deployment from the outside.

This came up directly: a token was rotated earlier today and there was no way to confirm it landed short of manually searching on the live site.

## What this adds

```json
"checks": {
  "siteUrl":     { "configured": true, "value": "https://..." },
  "githubToken": { "configured": true }
}
```

**Presence only — no value, prefix, length, or hash.** The endpoint is public and uncached, so a boolean is the entire safe surface. This is deliberately asymmetric with `siteUrl`, which exposes its value because `NEXT_PUBLIC_SITE_URL` is public by definition. The type carries a comment saying so, since the obvious "helpful" additions here are all leaks.

The production health check now asserts `configured === true` against deployed targets, and asserts the body never matches `/gh[pousr]_/`.

## What it does and does not prove

It proves the variable **reached the running deployment** — the failure mode that was invisible.

It does **not** prove the token is valid, unexpired, or accepted by GitHub. Only a live search does that. `docs/production.md` now states this explicitly in a new "Rotating `GITHUB_TOKEN`" runbook section, along with the add-before-revoke ordering and the fact that the app needs no token scopes.

## Validation

| Check | Result |
| --- | --- |
| `npx vitest run app/api/health/route.test.ts` | 4 passed |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run check:agent-docs` | pass |
| `npm run build` | pass |

Unit tests cover token set, empty, and whitespace-only, and assert `Object.keys(body.checks.githubToken)` is exactly `["configured"]` so a future `value` field fails the test rather than shipping.

I also ran the built server and curled the endpoint with `GITHUB_TOKEN=ghp_fake_value_should_not_appear`: it returned `{"configured": true}` and the fake token did not appear anywhere in the body. I attempted the unset and whitespace cases the same way, but the server teardown between cases hung and I stopped rather than keep fighting it — those two states are covered by the unit tests above, which pass.

The full `npm test` suite still fails on this machine (Node 26 vs pinned Node 22, jsdom `localStorage`), unrelated to this change. CI on Node 22 is the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)