### PR TITLE
feat(security): collect CSP violation reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Added
 
+- CSP violation reporting. The report-only policy now names a reporting destination through `report-uri`, `report-to`, and the `Reporting-Endpoints` header, and `/api/csp-report` records violations as structured `csp_violation` log events. Reported URLs are reduced to origin and path so searched usernames cannot reach logs, and the original policy and script sample are never read.
 - `/api/health` now reports whether `GITHUB_TOKEN` is configured, so a rotation that never reached the running deployment is visible without a live search. Presence only is reported, never the value. The production health check asserts it against deployed targets.
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,9 +10,10 @@ This roadmap is intentionally lightweight. It captures useful next ideas without
 
 ## Later
 
-- Add a tuned `Content-Security-Policy-Report-Only` header.
-- Observe CSP behavior in Vercel preview and production before enforcing it.
-- Tighten the CSP gradually once Next.js runtime behavior and Vercel Analytics are confirmed.
+- Observe `csp_violation` events from preview and production traffic, then tighten the policy against
+  what actually fires.
+- Replace `'unsafe-inline'` and `'unsafe-eval'` in `script-src` with per-request nonces before
+  enforcing the policy, once Next.js runtime behavior and Vercel Analytics are confirmed.
 - Add label sync automation if manual label management becomes annoying.
 
 ## Maybe

--- a/app/api/csp-report/route.test.ts
+++ b/app/api/csp-report/route.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "@/app/logger";
+import { POST } from "./route";
+
+function postReport(body: unknown, contentType = "application/csp-report") {
+  return POST(
+    new Request("https://my-first-commit-eta.vercel.app/api/csp-report", {
+      method: "POST",
+      headers: { "content-type": contentType },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+  );
+}
+
+function violationCalls(warn: ReturnType<typeof vi.spyOn>) {
+  return warn.mock.calls
+    .map(([logEvent]) => logEvent as { event: string; fields?: Record<string, unknown> })
+    .filter((logEvent) => logEvent.event === "csp_violation");
+}
+
+describe("POST /api/csp-report", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("records a report-uri violation with sanitized fields", async () => {
+    const response = await postReport({
+      "csp-report": {
+        "document-uri": "https://my-first-commit-eta.vercel.app/",
+        "violated-directive": "script-src-elem",
+        "effective-directive": "script-src-elem",
+        "blocked-uri": "https://evil.example/x.js",
+        disposition: "report",
+        "status-code": 200,
+        "source-file": "https://my-first-commit-eta.vercel.app/app.js",
+        "line-number": 12,
+        "column-number": 5,
+      },
+    });
+
+    expect(response.status).toBe(204);
+
+    const [violation] = violationCalls(warn);
+
+    expect(violation.fields).toEqual({
+      documentUri: "https://my-first-commit-eta.vercel.app/",
+      blockedUri: "https://evil.example/x.js",
+      effectiveDirective: "script-src-elem",
+      disposition: "report",
+      statusCode: 200,
+      sourceFile: "https://my-first-commit-eta.vercel.app/app.js",
+      lineNumber: 12,
+      columnNumber: 5,
+    });
+  });
+
+  it("records Reporting API violations and ignores other report types", async () => {
+    const response = await postReport(
+      [
+        {
+          type: "deprecation",
+          body: { id: "unrelated" },
+        },
+        {
+          type: "csp-violation",
+          body: {
+            documentURL: "https://my-first-commit-eta.vercel.app/privacy",
+            effectiveDirective: "img-src",
+            blockedURL: "https://tracker.example/pixel.gif",
+            disposition: "report",
+          },
+        },
+      ],
+      "application/reports+json",
+    );
+
+    expect(response.status).toBe(204);
+
+    const violations = violationCalls(warn);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].fields).toMatchObject({
+      documentUri: "https://my-first-commit-eta.vercel.app/privacy",
+      blockedUri: "https://tracker.example/pixel.gif",
+      effectiveDirective: "img-src",
+    });
+  });
+
+  it("strips the query string so searched usernames never reach logs", async () => {
+    await postReport({
+      "csp-report": {
+        "document-uri": "https://my-first-commit-eta.vercel.app/?user=octocat#results",
+        referrer: "https://my-first-commit-eta.vercel.app/?user=octocat",
+        "effective-directive": "style-src",
+        "blocked-uri": "https://cdn.example/style.css?token=abc123",
+      },
+    });
+
+    const [violation] = violationCalls(warn);
+
+    expect(violation.fields?.documentUri).toBe("https://my-first-commit-eta.vercel.app/");
+    expect(violation.fields?.blockedUri).toBe("https://cdn.example/style.css");
+
+    const serialized = JSON.stringify(violation);
+
+    expect(serialized).not.toContain("octocat");
+    expect(serialized).not.toContain("abc123");
+    expect(serialized).not.toContain("referrer");
+  });
+
+  it("reduces opaque schemes to the scheme and keeps CSP keywords", async () => {
+    await postReport({
+      "csp-report": {
+        "document-uri": "https://my-first-commit-eta.vercel.app/",
+        "effective-directive": "script-src",
+        "blocked-uri": "data:text/html,<script>alert(document.cookie)</script>",
+      },
+    });
+    await postReport({
+      "csp-report": {
+        "document-uri": "https://my-first-commit-eta.vercel.app/",
+        "effective-directive": "script-src",
+        "blocked-uri": "inline",
+      },
+    });
+
+    const violations = violationCalls(warn);
+
+    expect(violations[0].fields?.blockedUri).toBe("data:");
+    expect(JSON.stringify(violations[0])).not.toContain("alert");
+    expect(violations[1].fields?.blockedUri).toBe("inline");
+  });
+
+  it("never logs the original policy or the script sample", async () => {
+    await postReport({
+      "csp-report": {
+        "document-uri": "https://my-first-commit-eta.vercel.app/",
+        "effective-directive": "script-src",
+        "blocked-uri": "inline",
+        "original-policy": "default-src 'self'; script-src 'self' 'unsafe-inline'",
+        "script-sample": "const secret = 'do-not-log-me'",
+      },
+    });
+
+    const serialized = JSON.stringify(violationCalls(warn));
+
+    expect(serialized).not.toContain("do-not-log-me");
+    expect(serialized).not.toContain("original-policy");
+    expect(serialized).not.toContain("originalPolicy");
+    expect(serialized).not.toContain("unsafe-inline");
+  });
+
+  it("rejects an oversized body without parsing it", async () => {
+    const response = await postReport("x".repeat(16_385));
+
+    expect(response.status).toBe(413);
+    expect(violationCalls(warn)).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "csp_report_too_large" }) as never,
+    );
+  });
+
+  it("absorbs malformed and unrecognized payloads", async () => {
+    const malformed = await postReport("{not json");
+
+    expect(malformed.status).toBe(204);
+
+    const unrecognized = await postReport({ unexpected: true });
+
+    expect(unrecognized.status).toBe(204);
+    expect(violationCalls(warn)).toHaveLength(0);
+  });
+});

--- a/app/api/csp-report/route.ts
+++ b/app/api/csp-report/route.ts
@@ -1,0 +1,166 @@
+import { logger } from "@/app/logger";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+// Reports arrive unauthenticated from any browser, so the body is untrusted and unbounded. Anything
+// larger than this is not a real violation report.
+const MAX_BODY_BYTES = 16_384;
+
+// CSP substitutes a bare keyword for a URL in some violations, so these are not parse failures.
+const URL_KEYWORDS = new Set([
+  "inline",
+  "eval",
+  "self",
+  "data",
+  "blob",
+  "wasm-eval",
+  "wasm-unsafe-eval",
+  "trusted-types-policy",
+  "trusted-types-sink",
+]);
+
+// Schemes whose body carries the content itself. Report the scheme and drop the payload.
+const OPAQUE_PROTOCOLS = new Set(["data:", "blob:", "filesystem:", "javascript:"]);
+
+/**
+ * Reduce a reported URL to origin + path.
+ *
+ * Query strings are dropped because the app puts the searched username in `?user=`, and search
+ * usernames must not reach logs. Fragments are dropped for the same reason.
+ */
+function safeUrl(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed === "") {
+    return null;
+  }
+
+  if (URL_KEYWORDS.has(trimmed)) {
+    return trimmed;
+  }
+
+  try {
+    const url = new URL(trimmed);
+
+    if (OPAQUE_PROTOCOLS.has(url.protocol)) {
+      return url.protocol;
+    }
+
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+function safeNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function safeString(value: unknown, maxLength = 128): string | null {
+  return typeof value === "string" && value.trim() !== "" ? value.trim().slice(0, maxLength) : null;
+}
+
+type ViolationFields = {
+  documentUri: string | null;
+  blockedUri: string | null;
+  effectiveDirective: string | null;
+  disposition: string | null;
+  statusCode: number | null;
+  sourceFile: string | null;
+  lineNumber: number | null;
+  columnNumber: number | null;
+};
+
+/**
+ * Normalize the two report shapes browsers send.
+ *
+ * `report-uri` posts `{"csp-report": {...}}` with hyphenated keys. The Reporting API (`report-to`)
+ * posts an array of `{type, body}` with camelCased keys. Both are accepted so reporting keeps
+ * working as browsers migrate.
+ *
+ * `original-policy` and `script-sample` are deliberately never read: the policy is long and already
+ * known, and the sample can contain page content or user input.
+ */
+function normalizeReports(parsed: unknown): ViolationFields[] {
+  const records: Record<string, unknown>[] = [];
+
+  if (Array.isArray(parsed)) {
+    for (const entry of parsed) {
+      if (entry && typeof entry === "object") {
+        const { type, body } = entry as { type?: unknown; body?: unknown };
+
+        if (type === "csp-violation" && body && typeof body === "object") {
+          records.push(body as Record<string, unknown>);
+        }
+      }
+    }
+  } else if (parsed && typeof parsed === "object") {
+    const legacy = (parsed as Record<string, unknown>)["csp-report"];
+
+    if (legacy && typeof legacy === "object") {
+      records.push(legacy as Record<string, unknown>);
+    }
+  }
+
+  return records.map((record) => ({
+    documentUri: safeUrl(record["documentURL"] ?? record["document-uri"]),
+    blockedUri: safeUrl(record["blockedURL"] ?? record["blocked-uri"]),
+    effectiveDirective: safeString(
+      record["effectiveDirective"] ?? record["effective-directive"] ?? record["violated-directive"],
+      64,
+    ),
+    disposition: safeString(record["disposition"], 16),
+    statusCode: safeNumber(record["statusCode"] ?? record["status-code"]),
+    sourceFile: safeUrl(record["sourceFile"] ?? record["source-file"]),
+    lineNumber: safeNumber(record["lineNumber"] ?? record["line-number"]),
+    columnNumber: safeNumber(record["columnNumber"] ?? record["column-number"]),
+  }));
+}
+
+export async function POST(request: Request) {
+  let body: string;
+
+  try {
+    body = await request.text();
+  } catch {
+    logger.warn({ event: "csp_report_unreadable" });
+
+    return new Response(null, { status: 204 });
+  }
+
+  if (body.length > MAX_BODY_BYTES) {
+    logger.warn({ event: "csp_report_too_large", fields: { bytes: body.length } });
+
+    return new Response(null, { status: 413 });
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    logger.warn({ event: "csp_report_malformed" });
+
+    return new Response(null, { status: 204 });
+  }
+
+  const violations = normalizeReports(parsed);
+
+  if (violations.length === 0) {
+    logger.warn({ event: "csp_report_empty" });
+
+    return new Response(null, { status: 204 });
+  }
+
+  for (const violation of violations) {
+    logger.warn({ event: "csp_violation", fields: { ...violation } });
+  }
+
+  // Browsers ignore the response body, and a report is never worth failing a page over.
+  return new Response(null, { status: 204 });
+}

--- a/docs/production.md
+++ b/docs/production.md
@@ -242,7 +242,55 @@ The app sets baseline security headers from `next.config.ts`:
 - `X-Frame-Options: DENY`
 - `Content-Security-Policy-Report-Only` for CSP tuning without blocking production traffic
 
-Content Security Policy is currently report-only. Review Vercel logs and browser reports before moving from report-only to enforcement.
+Content Security Policy is currently report-only. Review Vercel logs before moving from report-only to enforcement.
+
+### CSP Violation Reports
+
+The policy names a reporting destination through both `report-uri` and `report-to`, backed by the
+`Reporting-Endpoints` header. Browsers post violations to `/api/csp-report`, which logs them as
+structured `csp_violation` events. Without this, a report-only policy is unobservable: violations
+reach each visitor's browser console and nowhere else.
+
+Find them in Vercel Logs by searching for:
+
+```text
+csp_violation
+```
+
+Logged fields:
+
+- `documentUri`
+- `blockedUri`
+- `effectiveDirective`
+- `disposition`
+- `statusCode`
+- `sourceFile`
+- `lineNumber`
+- `columnNumber`
+
+URLs are reduced to origin and path. Query strings are dropped because the app puts the searched
+username in `?user=`, and search usernames must not reach logs. Opaque schemes such as `data:` are
+reduced to the scheme so an inline payload is not logged. The reported `original-policy` and
+`script-sample` are never read at all: the policy is long and already known, and the sample can
+contain page content or user input.
+
+Other events from the same endpoint indicate a malformed or hostile POST rather than a real
+violation: `csp_report_malformed`, `csp_report_empty`, `csp_report_too_large`, and
+`csp_report_unreadable`.
+
+### Moving CSP To Enforcement
+
+Do not simply rename the header. `script-src` currently allows `'unsafe-inline'` and `'unsafe-eval'`,
+so enforcing the policy as written would activate `frame-ancestors`, `base-uri`, `form-action`, and
+`default-src` without blocking injected inline script, which is the main thing CSP defends against.
+
+The intended order is:
+
+1. Collect `csp_violation` events from real traffic in preview and production.
+2. Tighten the policy against what actually fires.
+3. Replace `'unsafe-inline'` and `'unsafe-eval'` in `script-src` with per-request nonces, which
+   requires middleware and can break the Next.js inline bootstrap and Vercel Analytics.
+4. Only then rename the header to `Content-Security-Policy`.
 
 ## Accessibility Checks
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,8 @@ const appReleaseUrl =
     ? `https://github.com/scottdensmore/my-first-commit/releases/tag/${appRelease}`
     : "");
 
+const cspReportPath = "/api/csp-report";
+
 const contentSecurityPolicyReportOnly = [
   "default-src 'self'",
   "base-uri 'self'",
@@ -31,6 +33,11 @@ const contentSecurityPolicyReportOnly = [
   "style-src 'self' 'unsafe-inline'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com",
   "connect-src 'self' https://vitals.vercel-insights.com https://*.vercel-insights.com",
+  // Both are sent on purpose. report-uri is deprecated but still the only directive some browsers
+  // honor; report-to is the Reporting API replacement and needs the Reporting-Endpoints header
+  // below. Browsers that support both ignore report-uri, so reports are not duplicated.
+  `report-uri ${cspReportPath}`,
+  "report-to csp-endpoint",
 ].join("; ");
 
 const securityHeaders = [
@@ -53,6 +60,10 @@ const securityHeaders = [
   {
     key: "Content-Security-Policy-Report-Only",
     value: contentSecurityPolicyReportOnly,
+  },
+  {
+    key: "Reporting-Endpoints",
+    value: `csp-endpoint="${cspReportPath}"`,
   },
 ];
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -14,6 +14,11 @@ function expectSecurityHeaders(response: APIResponse) {
   expect(headers["x-frame-options"]).toBe("DENY");
   expect(headers["content-security-policy-report-only"]).toContain("default-src 'self'");
   expect(headers["content-security-policy-report-only"]).toContain("frame-ancestors 'none'");
+  // Without a reporting destination the report-only policy is unobservable: violations reach the
+  // browser console and nowhere else.
+  expect(headers["content-security-policy-report-only"]).toContain("report-uri /api/csp-report");
+  expect(headers["content-security-policy-report-only"]).toContain("report-to csp-endpoint");
+  expect(headers["reporting-endpoints"]).toContain('csp-endpoint="/api/csp-report"');
 }
 
 async function searchForUsername(page: Page, username: string) {
@@ -271,6 +276,26 @@ test("health endpoint reports app status without caching", async ({ request }) =
   }
 
   expect(JSON.stringify(body)).not.toMatch(/gh[pousr]_/);
+});
+
+test("csp report endpoint accepts a violation report", async ({ request }) => {
+  // Local only. Against production this would write a synthetic violation into the very logs the
+  // endpoint exists to make trustworthy.
+  test.skip(isDeployedTarget, "csp report posting only runs against the local Playwright server");
+
+  const response = await request.post("/api/csp-report", {
+    headers: { "content-type": "application/csp-report" },
+    data: {
+      "csp-report": {
+        "document-uri": "http://localhost/",
+        "effective-directive": "img-src",
+        "blocked-uri": "https://example.test/pixel.gif",
+        disposition: "report",
+      },
+    },
+  });
+
+  expect(response.status()).toBe(204);
 });
 
 test.describe("local mocked commit search states", () => {


### PR DESCRIPTION
## Why

The report-only CSP named **no reporting destination**. Violations went to each visitor's browser console and nowhere else, so the roadmap item "observe CSP behavior in preview and production before enforcing it" was not actually possible. The policy looked like it was gathering data and was gathering nothing.

## What this adds

`/api/csp-report`, wired up through `report-uri`, `report-to`, and the `Reporting-Endpoints` header. Both directives are sent because some browsers still honor only `report-uri`; browsers that support both ignore it, so reports are not duplicated.

Violations land in Vercel Logs as structured `csp_violation` events with `documentUri`, `blockedUri`, `effectiveDirective`, `disposition`, `statusCode`, `sourceFile`, `lineNumber`, `columnNumber`.

## Sanitizing, and why it is not optional here

A CSP report echoes the page URL back to the server — and this app puts the searched username in `?user=`. Logging reports naively would put **search usernames into production logs**, which `docs/production.md` explicitly forbids. So:

- URLs are reduced to origin + path; query and fragment are dropped.
- Opaque schemes (`data:`, `blob:`, `javascript:`) collapse to just the scheme, so an inline payload is never logged.
- `original-policy` and `script-sample` are never read at all. The policy is long and already known; the sample can contain page content or user input.

The endpoint is public and unauthenticated, so the body is capped at 16 KiB and every parse failure returns without throwing. Malformed or hostile POSTs log `csp_report_malformed`, `csp_report_empty`, `csp_report_too_large`, or `csp_report_unreadable` rather than being mistaken for violations.

## What this deliberately does not do

It does not enforce the policy. `script-src` still allows `'unsafe-inline'` and `'unsafe-eval'`, so renaming the header today would activate `frame-ancestors`, `base-uri`, `form-action`, and `default-src` **without blocking injected inline script** — the main thing CSP defends against. That would look like a security win while delivering little.

`docs/production.md` now documents the real sequence: collect reports → tighten against what fires → replace `'unsafe-inline'`/`'unsafe-eval'` with per-request nonces (needs middleware, can break the Next.js inline bootstrap and Vercel Analytics) → only then enforce. `ROADMAP.md` is updated to match, and the completed "add a tuned report-only header" item is dropped.

## Validation

| Check | Result |
| --- | --- |
| `npx vitest run app/api` | 11 passed (7 new) |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run check:agent-docs` | pass |
| `npm run build` | pass, `/api/csp-report` registered |

Unit tests cover both report shapes, non-CSP entries in a Reporting API batch, query-string stripping, `data:` collapsing, sample/policy exclusion, oversized bodies, and malformed payloads.

Verified against a running production build:

```
Content-Security-Policy-Report-Only: ...; report-uri /api/csp-report; report-to csp-endpoint
Reporting-Endpoints: csp-endpoint="/api/csp-report"

POST valid report          -> 204, logged csp_violation
POST 17 KB body            -> 413, logged csp_report_too_large
occurrences of "octocat" / "secret123" in logs -> 0
```

That last line is the one that mattered: the posted report contained `?user=octocat` and `?t=secret123`, and neither reached the log.

The e2e suite asserts the new headers on every response. The endpoint POST test is local-only — running it against production would write a synthetic violation into the very logs this endpoint exists to make trustworthy.

Full `npm test` still fails on this machine (Node 26 vs pinned Node 22, jsdom `localStorage`), unrelated. CI on Node 22 is the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)