### PR TITLE
feat(labels): reconcile GitHub labels from .github/labels.yml

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,43 +1,58 @@
+# Colors are quoted on purpose. YAML reads an unquoted 5319e7 as scientific notation and 000000 as
+# the integer zero, so an unquoted color silently stops being a string.
+
 - name: bug
-  color: d73a4a
+  color: "d73a4a"
   description: Something is broken or behaving unexpectedly.
 
 - name: feature
-  color: 0e8a16
+  color: "0e8a16"
   description: A new user-facing capability.
 
 - name: maintenance
-  color: cfd3d7
+  color: "cfd3d7"
   description: Cleanup, refactors, chores, or upkeep that does not change user behavior.
 
 - name: dependencies
-  color: 0366d6
+  color: "0366d6"
   description: Dependency updates, lockfile changes, or package maintenance.
 
 - name: security
-  color: b60205
+  color: "b60205"
   description: Security hardening, vulnerabilities, tokens, headers, or dependency advisories.
 
 - name: production
-  color: fbca04
+  color: "fbca04"
   description: Deployment, health checks, monitoring, Vercel, or production incidents.
 
 - name: docs
-  color: 0075ca
+  color: "0075ca"
   description: README, runbook, changelog, contributing, architecture, or QA documentation.
 
 - name: accessibility
-  color: 5319e7
+  color: "5319e7"
   description: Keyboard, focus, landmarks, announcements, or screen-reader improvements.
 
 - name: testing
-  color: 1d76db
+  color: "1d76db"
   description: Unit, e2e, CI, production health, or QA coverage.
 
 - name: release
-  color: 0052cc
+  color: "0052cc"
   description: Tags, changelog entries, release notes, or GitHub releases.
 
 - name: privacy
-  color: 6f42c1
+  color: "6f42c1"
   description: Search data handling, analytics boundaries, or local browser storage.
+
+# Created automatically by Dependabot, which applies them to its own pull requests. They are listed
+# here so `npm run sync:labels -- --prune` does not delete labels the repository actually uses.
+# Colors and descriptions match what Dependabot creates, so syncing leaves them untouched.
+
+- name: javascript
+  color: "168700"
+  description: Pull requests that update javascript code
+
+- name: github_actions
+  color: "000000"
+  description: Pull requests that update GitHub Actions code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,8 @@ jobs:
       - name: Check agent instruction files
         run: npm run check:agent-docs
 
+      - name: Check label definitions
+        run: npm run check:labels
+
       - name: Build
         run: npm run build

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,61 @@
+name: Sync Labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - scripts/sync-labels.mjs
+      - .github/workflows/label-sync.yml
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report the changes without applying them.
+        type: boolean
+        default: true
+      prune:
+        description: Delete labels that are missing from .github/labels.yml. This removes them from every issue and pull request that carries them.
+        type: boolean
+        default: false
+
+# Labels live under the issues scope.
+permissions:
+  issues: write
+
+jobs:
+  sync-labels:
+    name: Reconcile labels with .github/labels.yml
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # On push the inputs are empty, so the sync applies creates and updates and never prunes.
+      # Deleting a label is only ever reachable through a deliberate manual dispatch.
+      - name: Sync labels
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          PRUNE: ${{ inputs.prune }}
+        run: |
+          args=()
+
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+
+          if [ "$PRUNE" = "true" ]; then
+            args+=(--prune)
+          fi
+
+          node scripts/sync-labels.mjs "${args[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ npm run lint             # eslint
 npm run format           # prettier --write
 npm run format:check     # prettier --check (CI gate)
 npm run check:agent-docs # verify agent pointer files have not drifted
+npm run check:labels     # validate .github/labels.yml
+npm run sync:labels      # reconcile GitHub labels with .github/labels.yml
 npm run build
 npm run test:e2e         # playwright; boots its own dev server on :3100
 ```
@@ -27,7 +29,7 @@ npm run test:e2e         # playwright; boots its own dev server on :3100
 Full pre-PR validation, matching the `CI / validate` job:
 
 ```bash
-npm test && npm run lint && npm run format:check && npm run check:agent-docs && npm run build && npm run test:e2e
+npm test && npm run lint && npm run format:check && npm run check:agent-docs && npm run check:labels && npm run build && npm run test:e2e
 ```
 
 ## Layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Added
 
+- Label sync automation. `.github/labels.yml` is reconciled with GitHub by the `Sync Labels` workflow on merge, or locally through `npm run sync:labels`. Deleting labels is opt-in, and CI validates the label file on every pull request.
 - CSP violation reporting. The report-only policy now names a reporting destination through `report-uri`, `report-to`, and the `Reporting-Endpoints` header, and `/api/csp-report` records violations as structured `csp_violation` log events. Reported URLs are reduced to origin and path so searched usernames cannot reach logs, and the original policy and script sample are never read.
 - `/api/health` now reports whether `GITHUB_TOKEN` is configured, so a rotation that never reached the running deployment is visible without a live search. Presence only is reported, never the value. The production health check asserts it against deployed targets.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Thanks for helping improve My First Commit. Keep changes small, tested, and easy
    npm run lint
    npm run format:check
    npm run check:agent-docs
+   npm run check:labels
    npm run build
    npm run test:e2e
    ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,6 @@ This roadmap is intentionally lightweight. It captures useful next ideas without
   what actually fires.
 - Replace `'unsafe-inline'` and `'unsafe-eval'` in `script-src` with per-request nonces before
   enforcing the policy, once Next.js runtime behavior and Vercel Analytics are confirmed.
-- Add label sync automation if manual label management becomes annoying.
 
 ## Maybe
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,6 +55,7 @@ npm test
 npm run lint
 npm run format:check
 npm run check:agent-docs
+npm run check:labels
 npm run build
 ```
 
@@ -63,6 +64,9 @@ npm run build
 it, so notes captured by a coding agent (for example Claude Code's `#` shortcut) do not quietly
 accumulate in a tool-specific file. Move the content into `AGENTS.md`, then run
 `npm run check:agent-docs -- --fix` to restore the pointers.
+
+`npm run check:labels` validates `.github/labels.yml` offline, without a token or network access. See
+[labels](labels.md) for syncing labels to GitHub.
 
 Run the local browser health check:
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -24,22 +24,51 @@ Use labels to make issues and pull requests easy to scan. Keep the set small.
 - Use `maintenance` for small ownership improvements that are not visible to users.
 - Use `docs` for documentation-only changes.
 
-## Future Automation
+## Syncing
 
-The canonical label set is captured in `.github/labels.yml`.
+`.github/labels.yml` is the canonical label set. Edit that file and merge it to `main`; the
+`Sync Labels` workflow reconciles GitHub with it on any push that touches the file.
 
-To sync labels manually with GitHub CLI:
+Locally:
 
 ```bash
-gh label create bug --color d73a4a --description "Something is broken or behaving unexpectedly."
-gh label create feature --color 0e8a16 --description "A new user-facing capability."
-gh label create maintenance --color cfd3d7 --description "Cleanup, refactors, chores, or upkeep that does not change user behavior."
-gh label create dependencies --color 0366d6 --description "Dependency updates, lockfile changes, or package maintenance."
-gh label create security --color b60205 --description "Security hardening, vulnerabilities, tokens, headers, or dependency advisories."
-gh label create production --color fbca04 --description "Deployment, health checks, monitoring, Vercel, or production incidents."
-gh label create docs --color 0075ca --description "README, runbook, changelog, contributing, architecture, or QA documentation."
-gh label create accessibility --color 5319e7 --description "Keyboard, focus, landmarks, announcements, or screen-reader improvements."
-gh label create testing --color 1d76db --description "Unit, e2e, CI, production health, or QA coverage."
+npm run check:labels                      # validate the file, no network, no token
+npm run sync:labels -- --dry-run          # report what would change
+npm run sync:labels                       # create and update
 ```
 
-Use `gh label edit <name>` instead of `create` when a label already exists. Add automated label syncing later only if manual sync becomes annoying.
+The local commands need `GITHUB_TOKEN` and `GITHUB_REPOSITORY`:
+
+```bash
+GITHUB_REPOSITORY=scottdensmore/my-first-commit GITHUB_TOKEN="$(gh auth token)" \
+  npm run sync:labels -- --dry-run
+```
+
+`npm run check:labels` also runs in CI, so an invalid label file fails the pull request rather than
+the sync.
+
+### Colors Must Be Quoted
+
+YAML reads an unquoted `5319e7` as scientific notation and `000000` as the integer zero, so a color
+silently stops being a string. Every color in `.github/labels.yml` is quoted, and the validator
+rejects one that is not with a message naming the problem.
+
+### Deleting Labels
+
+Syncing never deletes anything by default. Deleting a label removes it from every issue and pull
+request that carries it, and that cannot be undone.
+
+Pruning is available through `--prune`, and from the `Sync Labels` workflow only as a deliberate
+manual dispatch with the `prune` input checked. Run it as a dry run first:
+
+```bash
+npm run sync:labels -- --dry-run --prune
+```
+
+### Dependabot's Labels
+
+Dependabot creates `javascript` and `github_actions` on its own and applies them to its pull
+requests. Both are listed in `.github/labels.yml` with the values Dependabot uses, so a sync leaves
+them untouched and a prune does not delete labels the repository is actually using.
+
+If Dependabot later introduces another label, add it to the file before pruning.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.12",
+        "js-yaml": "4.3.1",
         "jsdom": "^29.1.1",
         "prettier": "3.9.6",
         "tailwindcss": "^4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "test:e2e:deployed": "PLAYWRIGHT_BASE_URL=https://my-first-commit-eta.vercel.app playwright test"
+    "test:e2e:deployed": "PLAYWRIGHT_BASE_URL=https://my-first-commit-eta.vercel.app playwright test",
+    "check:labels": "node scripts/sync-labels.mjs --check",
+    "sync:labels": "node scripts/sync-labels.mjs"
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
@@ -40,6 +42,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.12",
+    "js-yaml": "4.3.1",
     "jsdom": "^29.1.1",
     "prettier": "3.9.6",
     "tailwindcss": "^4",

--- a/scripts/sync-labels.mjs
+++ b/scripts/sync-labels.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+// Reconciles GitHub labels with .github/labels.yml, the canonical label set.
+//
+// Deleting a label removes it from every issue and pull request that carries it, and that cannot be
+// undone. Pruning is therefore opt-in, never the default. Dependabot also creates its own labels
+// (`javascript`, `github_actions`) without asking, so anything it owns must be listed in the file
+// before pruning is safe.
+//
+// Usage:
+//   node scripts/sync-labels.mjs --check      validate the file offline, no network, no token
+//   node scripts/sync-labels.mjs --dry-run    report what would change
+//   node scripts/sync-labels.mjs              create and update labels
+//   node scripts/sync-labels.mjs --prune      also delete labels missing from the file
+
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { load } from "js-yaml";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const LABELS_FILE = ".github/labels.yml";
+const HEX_COLOR = /^[0-9a-f]{6}$/;
+// GitHub rejects longer descriptions with a 422 that does not name the offending field.
+const MAX_DESCRIPTION_LENGTH = 100;
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function validate(labels) {
+  if (!Array.isArray(labels) || labels.length === 0) {
+    fail(`${LABELS_FILE} must contain a non-empty list of labels.`);
+  }
+
+  const problems = [];
+  const seen = new Set();
+
+  for (const [index, label] of labels.entries()) {
+    const at = `${LABELS_FILE}[${index}]`;
+
+    if (!label || typeof label !== "object") {
+      problems.push(`${at}: expected a mapping with name, color, and description.`);
+      continue;
+    }
+
+    const { name, color, description } = label;
+
+    if (typeof name !== "string" || name.trim() === "") {
+      problems.push(`${at}: name is required.`);
+    } else if (seen.has(name)) {
+      problems.push(`${at}: duplicate label name "${name}".`);
+    } else {
+      seen.add(name);
+    }
+
+    if (typeof color === "number") {
+      // YAML reads 5319e7 as scientific notation and 000000 as an integer, so an unquoted color
+      // silently stops being a string. Colors must be quoted in the file.
+      problems.push(
+        `${at} (${name}): color parsed as the number ${color}. Quote it, for example color: "5319e7".`,
+      );
+    } else if (typeof color !== "string" || !HEX_COLOR.test(color)) {
+      problems.push(`${at} (${name}): color must be six lowercase hex digits without "#".`);
+    }
+
+    if (typeof description !== "string" || description.trim() === "") {
+      problems.push(`${at} (${name}): description is required.`);
+    } else if (description.length > MAX_DESCRIPTION_LENGTH) {
+      problems.push(
+        `${at} (${name}): description is ${description.length} characters, over GitHub's ${MAX_DESCRIPTION_LENGTH}.`,
+      );
+    }
+  }
+
+  if (problems.length > 0) {
+    fail(`${LABELS_FILE} is invalid:\n${problems.map((line) => `  - ${line}`).join("\n")}`);
+  }
+}
+
+function resolveRepo() {
+  const fromEnv = process.env.GITHUB_REPOSITORY?.trim();
+
+  if (fromEnv) {
+    const [owner, repo] = fromEnv.split("/");
+
+    if (owner && repo) {
+      return { owner, repo };
+    }
+  }
+
+  fail("Set GITHUB_REPOSITORY to <owner>/<repo>.");
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const check = args.has("--check");
+  const dryRun = args.has("--dry-run");
+  const prune = args.has("--prune");
+
+  const raw = await readFile(join(repoRoot, LABELS_FILE), "utf8");
+  const desired = load(raw);
+
+  validate(desired);
+
+  if (check) {
+    console.log(`${LABELS_FILE} is valid (${desired.length} labels).`);
+    return;
+  }
+
+  const token = process.env.GITHUB_TOKEN?.trim();
+
+  if (!token) {
+    fail("Set GITHUB_TOKEN to a token with permission to manage labels.");
+  }
+
+  const { owner, repo } = resolveRepo();
+  const { Octokit } = await import("octokit");
+  const octokit = new Octokit({ auth: token });
+
+  const existing = await octokit.paginate("GET /repos/{owner}/{repo}/labels", {
+    owner,
+    repo,
+    per_page: 100,
+  });
+  const existingByName = new Map(existing.map((label) => [label.name, label]));
+
+  const planned = { created: [], updated: [], deleted: [], unchanged: [] };
+
+  for (const label of desired) {
+    const current = existingByName.get(label.name);
+
+    if (!current) {
+      planned.created.push(label.name);
+
+      if (!dryRun) {
+        await octokit.request("POST /repos/{owner}/{repo}/labels", { owner, repo, ...label });
+      }
+
+      continue;
+    }
+
+    // GitHub returns null rather than an empty string for a label with no description.
+    const drifted =
+      current.color.toLowerCase() !== label.color ||
+      (current.description ?? "") !== label.description;
+
+    if (!drifted) {
+      planned.unchanged.push(label.name);
+      continue;
+    }
+
+    planned.updated.push(label.name);
+
+    if (!dryRun) {
+      await octokit.request("PATCH /repos/{owner}/{repo}/labels/{name}", {
+        owner,
+        repo,
+        name: label.name,
+        new_name: label.name,
+        color: label.color,
+        description: label.description,
+      });
+    }
+  }
+
+  const desiredNames = new Set(desired.map((label) => label.name));
+  const extra = existing.map((label) => label.name).filter((name) => !desiredNames.has(name));
+
+  for (const name of extra) {
+    if (!prune) {
+      continue;
+    }
+
+    planned.deleted.push(name);
+
+    if (!dryRun) {
+      await octokit.request("DELETE /repos/{owner}/{repo}/labels/{name}", { owner, repo, name });
+    }
+  }
+
+  const tense = (applied, pending) => (dryRun ? pending : applied);
+
+  console.log(`${owner}/${repo}${dryRun ? " (dry run, nothing changed)" : ""}`);
+  console.log(`  ${tense("created", "would create")}: ${planned.created.join(", ") || "none"}`);
+  console.log(`  ${tense("updated", "would update")}: ${planned.updated.join(", ") || "none"}`);
+  console.log(`  unchanged: ${planned.unchanged.length}`);
+
+  if (prune) {
+    console.log(`  ${tense("deleted", "would delete")}: ${planned.deleted.join(", ") || "none"}`);
+  } else if (extra.length > 0) {
+    // Silence here would read as "the file matches GitHub" when it does not.
+    console.log(`  not in ${LABELS_FILE} (kept, --prune would delete): ${extra.join(", ")}`);
+  }
+}
+
+main().catch((error) => {
+  fail(error instanceof Error ? error.message : String(error));
+});


### PR DESCRIPTION
## Why

`docs/labels.md` held a wall of `gh label create` commands to run by hand, and they had already drifted: **`release` and `privacy` are in `.github/labels.yml` but were never created on GitHub.** A canonical file nobody applies is just a second place to be wrong.

## What this adds

- `scripts/sync-labels.mjs` — reconciles GitHub with the file.
- `.github/workflows/label-sync.yml` — runs on any push to `main` touching the label file or the script, plus manual dispatch.
- `npm run check:labels` — offline validation, no token or network. Added to `CI / validate`, so a broken label file fails the PR rather than the sync.

```
npm run check:labels               # validate
npm run sync:labels -- --dry-run   # report
npm run sync:labels                # create + update
npm run sync:labels -- --prune     # also delete
```

## Deleting is opt-in

Deleting a label removes it from every issue and PR that carries it, and cannot be undone. So a push **never** prunes. Pruning requires `--prune` locally or a deliberate manual dispatch with the input checked.

When not pruning, extra labels are still *reported* — silence there would read as "the file matches GitHub" when it doesn't.

## Two things found while building it

**1. Dependabot owns labels nobody wrote down.** It creates `javascript` and `github_actions` itself and applies them to its PRs. A prune would have deleted both. They're now listed with the exact values Dependabot uses, so a sync leaves them alone (`unchanged: 11` confirms no churn) and a prune can't take out labels the repo actually uses.

**2. The colors were never strings.** YAML reads unquoted `5319e7` as scientific notation — `53190000000` — and `000000` as integer zero. `accessibility`'s color had this problem in the existing file. The validator caught it on its first run, before any code went near the GitHub API. All colors are now quoted, and an unquoted one fails with a message that names the cause:

```
.github/labels.yml[7] (accessibility): color parsed as the number 53190000000.
Quote it, for example color: "5319e7".
```

## Validation

Dry run against the real repository:

```
scottdensmore/my-first-commit (dry run, nothing changed)
  would create: release, privacy
  would update: none
  unchanged: 11
  would delete: none
```

Validator failure paths were each exercised with a deliberately broken file: unquoted color (both the scientific-notation and integer-zero forms), duplicate names, over-length description, uppercase color, and an empty list — all rejected with exit 1 and a specific message.

`npm run lint`, `format:check`, `check:agent-docs`, `check:labels` pass; all three workflow files and the label file parse as YAML.

**Not run locally:** the full unit suite (Node 26 vs pinned Node 22, jsdom `localStorage`) and the browser-based e2e tests. Playwright 1.62 splits `chromium` from `chromium-headless-shell` and only the former had finished installing — the API-based e2e tests passed, page-based ones could not launch a browser. CI on Node 22 covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)