### PR TITLE
chore(release): prepare the 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ## Unreleased
 
+## 0.3.0 - 2026-08-01
+
 ### Added
 
 - Label sync automation. `.github/labels.yml` is reconciled with GitHub by the `Sync Labels` workflow on merge, or locally through `npm run sync:labels`. Deleting labels is opt-in, and CI validates the label file on every pull request.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-first-commit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-first-commit",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-first-commit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "engines": {
     "node": "22.x"


### PR DESCRIPTION
Cuts `0.3.0`. Minor rather than patch — three new capabilities plus two release-automation fixes.

## What changed

- `CHANGELOG.md`: `Unreleased` moved into `## 0.3.0 - 2026-08-01`, leaving an empty `Unreleased`.
- `package.json` / `package-lock.json`: version bumped to `0.3.0`.

No application code changes.

### Added
- Label sync automation
- CSP violation reporting
- `/api/health` reports whether `GITHUB_TOKEN` is configured

### Fixed
- Deployment releases no longer take the "Latest" pointer from the version release
- Promotion waits for CI instead of failing when the deploy chain finishes first

## Why this one is different

`0.2.0` shipped *before* both release fixes. This is the first version tag published with the Latest-pointer fix and the CI wait already in place — the release path exercised end to end in its repaired form.

Side effect: deployment tags become `v0.3.0-<sha>` after merge.

## Validation

**Everything below ran locally on Node 22**, the pinned version — a first for this session. Local Node was 26, which left `window.localStorage` undefined under jsdom and failed 36 unit tests all night. Node 22 was already installed via mise; it just wasn't being selected because `.nvmrc` support was disabled. That's now fixed, so local runs finally match CI.

| Check | Result |
| --- | --- |
| `npm audit` | pass, 0 vulnerabilities |
| `npm test` | **113 passed** |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run check:agent-docs` | pass |
| `npm run check:labels` | pass |
| `npm run build` | pass |
| `npm run test:e2e` | **17 passed** |

The `release.yml` changelog extraction was simulated against the new section: 12 lines, both subsections, stops cleanly before `## 0.2.0`.

## After merge

Tag `v0.3.0` on the merge commit and push, which triggers `Release` to publish using the `0.3.0` changelog section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)