### PR TITLE
fix(ci): restore deployment validation

### DIFF
--- a/app/api/csp-report/route.test.ts
+++ b/app/api/csp-report/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import { logger } from "@/app/logger";
 import { POST } from "./route";
 
@@ -12,14 +12,14 @@ function postReport(body: unknown, contentType = "application/csp-report") {
   );
 }
 
-function violationCalls(warn: ReturnType<typeof vi.spyOn>) {
+function violationCalls(warn: MockInstance<typeof logger.warn>) {
   return warn.mock.calls
-    .map(([logEvent]) => logEvent as { event: string; fields?: Record<string, unknown> })
+    .map(([logEvent]) => logEvent)
     .filter((logEvent) => logEvent.event === "csp_violation");
 }
 
 describe("POST /api/csp-report", () => {
-  let warn: ReturnType<typeof vi.spyOn>;
+  let warn: MockInstance<typeof logger.warn>;
 
   beforeEach(() => {
     warn = vi.spyOn(logger, "warn").mockImplementation(() => {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": "22.x"
+        "node": "24.x"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6672,9 +6672,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What changed

- Preserve the `logger.warn` method signature in the CSP report route spy so strict TypeScript can infer mock call arguments.
- Refresh the compatible transitive `nanoid` lock entry from 3.3.16 to 3.3.18 and synchronize the lockfile's root Node engine metadata with Node 24.

## Why

Vercel's `next build` failed during TypeScript checking because `ReturnType<typeof vi.spyOn>` erased the mocked method signature and left callback parameters implicitly typed as `any`. During full validation, the existing audit gate also began reporting the high-severity nanoid advisory GHSA-2v37-7h3g-55p8.

## Impact

Production behavior is unchanged. The test helper is now strictly typed, deployment builds can complete, and the existing dependency audit gate is clean.

## Validation

- `npm audit` (0 vulnerabilities)
- `npm test` (113 tests)
- focused CSP route tests (7 tests)
- `npm run test:e2e` against an isolated local server (17 tests)
- `npm run lint`
- `npm run format:check`
- `npm run check:agent-docs`
- `npm run check:labels`
- `npm run build`
- `npm ci --dry-run`
- pre-commit UI review, verifier PASS, and code review APPROVED