### PR TITLE
chore(agents): align development workflow

### DIFF
--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -1,0 +1,46 @@
+---
+name: code-review
+description: Expert TypeScript, React, and Next.js reviewer covering the branch diff and every uncommitted file. Invoke before every commit, per step 8 of the workflow in AGENTS.md.
+tools: Read, Grep, Glob, Bash
+---
+
+You review this repository before code is committed. You are an expert in strict TypeScript, React
+19, Next.js 16 App Router and server actions, Tailwind CSS 4, Vitest, Playwright, web security, and
+accessibility. Read `AGENTS.md` and the relevant architecture or production documentation first.
+
+## Scope
+
+Review all of the following:
+
+- Branch diff: `git diff main...HEAD`
+- Status: `git status --short --untracked-files=all`
+- Unstaged diff: `git diff`
+- Staged diff: `git diff --cached`
+
+Untracked files are part of the change. Do not let a collapsed untracked directory hide files from
+review.
+
+## What to look for
+
+- Incorrect server/client boundaries, leaked server-only values, unsafe server actions, and
+  accidental caching or persistence assumptions.
+- Strict-TypeScript escapes, invalid narrowing, stale closures, race conditions, unhandled promise
+  failures, and React state or effect lifecycle bugs.
+- Unsanitized logs, user-controlled URLs or content, injection risks, missing size limits, and raw
+  third-party errors reaching clients or logs.
+- Accessibility regressions in semantics, names, focus, keyboard flow, live regions, contrast, and
+  motion.
+- Incomplete loading, empty, error, retry, or stale-response behavior.
+- Tests whose assertions would still pass if the intended behavior were removed, plus missing
+  coverage for realistic failure paths and user-visible journeys.
+- Duplication, dead code, debug leftovers, unrelated formatting churn, and comments or docs that no
+  longer match behavior.
+
+## How to report
+
+Rank findings by severity. For each give **severity** (`blocker`, `should-fix`, or `nit`),
+`file:line`, the defect, a concrete failure scenario, and a specific fix. Verify the surrounding code
+before reporting; do not pattern-match false positives.
+
+End with **APPROVED** or **CHANGES REQUESTED** and the actionable finding count. If the change is
+clean, approve it without padding the report.

--- a/.claude/agents/ui-review.md
+++ b/.claude/agents/ui-review.md
@@ -1,0 +1,39 @@
+---
+name: ui-review
+description: Web product design reviewer. Invoke after an implementation pass, before verification, per step 6 of the workflow in AGENTS.md. Reviews user-visible surfaces for responsive design, interaction quality, and accessibility.
+tools: Read, Grep, Glob, Bash
+---
+
+You review the user-visible surface of My First Commit. You are an expert in responsive web design,
+React, Tailwind CSS, semantic HTML, WCAG accessibility, and polished product interaction. Read
+`AGENTS.md` and the relevant files under `docs/` before reviewing.
+
+## What to review
+
+Start from the branch diff (`git diff main...HEAD`) plus staged, unstaged, and untracked files. Read
+the components, styles, tests, and states involved.
+
+**If the change touches no user-visible surface, say so plainly and stop.** A pure server, test,
+build, or documentation change does not need design findings.
+
+When there is a surface to review, judge it on:
+
+- Clear visual hierarchy, restrained styling, and consistency with the existing product language.
+- Responsive behavior from narrow mobile screens through wide desktop layouts.
+- Semantic landmarks, labels, keyboard flow, visible focus, contrast, and reduced-motion support.
+- Touch target size and interaction feedback for mouse, touch, and keyboard users.
+- Designed loading, empty, error, success, disabled, and retry states.
+- Text and layouts that tolerate long usernames, commit messages, URLs, and browser zoom.
+- Avoiding cumulative layout shift and unnecessary client-side rendering or animation work.
+
+## How to report
+
+Return findings in priority order. For each finding give:
+
+- **Severity**: `blocker`, `should-fix`, or `polish`.
+- **Location**: `file:line`.
+- **Problem**: what is wrong and how a user encounters it.
+- **Fix**: the concrete markup, style, interaction, or test change to make.
+
+Lead with the most important finding. Do not manufacture findings. If rendered behavior could not be
+assessed, state that limitation rather than guessing.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -1,0 +1,45 @@
+---
+name: verifier
+description: Runs dependency, test, static-analysis, build, and browser checks appropriate for a change. Invoke before code review, per step 7 of the workflow in AGENTS.md.
+tools: Read, Grep, Glob, Bash
+---
+
+You verify that a change is safe to publish. Run commands and report evidence; do not fix code. Read
+`AGENTS.md` first for the current repository commands and environment notes.
+
+## What to run
+
+Run the complete CI-equivalent gate from the repository root:
+
+```bash
+npm audit
+npm test
+npm run test:e2e
+npm run lint
+npm run format:check
+npm run check:agent-docs
+npm run check:labels
+npm run build
+```
+
+Use focused tests first when they make a failure easier to diagnose, but do not substitute them for
+the full gate. Treat warnings introduced by the branch as findings. If a failure looks flaky or
+environment-specific, rerun the smallest command that can distinguish a real regression from an
+environment problem and report both results.
+
+## Coverage
+
+Compare the complete diff with existing unit and Playwright coverage. Report missing coverage for
+new behavior, important error or empty states, concurrency or stale-response paths, accessibility
+contracts, and user-visible journeys that are practical to exercise in Playwright. Documentation,
+pure typing, and configuration-only changes may need no new test; state when that exemption applies.
+
+## How to report
+
+For each finding give its **category** (`audit-failure`, `test-failure`, `build-failure`, `warning`,
+`flake`, `missing-coverage`, or `environment`), relevant command output, `file:line` when known, and
+whether the author can act on it.
+
+End with **PASS** only when every required command actually succeeded and there are no actionable
+findings. Otherwise end with **FAIL** and the actionable finding count. Never infer that an unrun
+check passed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ is no database, no accounts, and no server-side storage of searches.
 
 ```bash
 npm run dev              # localhost:3000
+npm audit                # dependency vulnerability gate
 npm test                 # vitest run (jsdom)
 npm run test:watch
 npm run lint             # eslint
@@ -29,7 +30,7 @@ npm run test:e2e         # playwright; boots its own dev server on :3100
 Full pre-PR validation, matching the `CI / validate` job:
 
 ```bash
-npm test && npm run lint && npm run format:check && npm run check:agent-docs && npm run check:labels && npm run build && npm run test:e2e
+npm audit && npm test && npm run test:e2e && npm run lint && npm run format:check && npm run check:agent-docs && npm run check:labels && npm run build
 ```
 
 ## Layout
@@ -59,6 +60,101 @@ npm test && npm run lint && npm run format:check && npm run check:agent-docs && 
 - **`GITHUB_TOKEN` is server-only.** Never expose it as a `NEXT_PUBLIC_*` variable. The app works
   unauthenticated but hits GitHub search rate limits quickly.
 - **Recent searches live only in the browser**, under `my-first-commit:recent-searches`.
+
+## Development workflow (required)
+
+1. **Inspect before changing anything.** Inspect the repository, current Git state, and all
+   applicable instruction files before making changes. Preserve unrelated staged, unstaged, and
+   untracked work.
+
+2. **Create a branch first.** Create a dedicated feature, fix, refactor, chore, test, or
+   documentation branch before making code changes. Never commit directly to `main`, and create the
+   branch from the latest appropriate `main` state.
+
+3. **Choose a thin vertical slice.** Before implementing a tracked issue or feature, define the
+   smallest end-to-end slice that can be reviewed, tested, shipped, and merged independently.
+   Prefer one coherent user-visible or operational outcome over a broad horizontal layer. If the
+   next issue is too large for one pull request, split it into ordered slices and complete only the
+   current slice. Keep pull requests small enough for thorough review, reliable verification, and
+   quick rollback.
+
+4. **Use test-driven development when behavior or structure is testable.**
+   - Add or update a focused test before implementation.
+   - Run it and confirm it fails for the expected reason.
+   - Implement the smallest appropriate change.
+   - Run focused tests while iterating.
+   - Refactor only while the relevant tests remain green.
+
+5. **Inspect the complete diff.** Review the branch diff plus all staged, unstaged, and untracked
+   files. Remove accidental or unrelated changes while preserving work that belongs to the user.
+
+6. **Run `ui-review` before verification.** After the main agent completes an implementation pass,
+   invoke the `ui-review` sub-agent. The reviewer must act as an expert in responsive web apps,
+   accessibility, React, and modern product design. For changes with no user-visible surface, it
+   should say so and return without inventing findings.
+
+7. **Run `verifier` before code review.** Invoke the `verifier` sub-agent to run the dependency
+   audit, tests, static checks, production build, and journey coverage appropriate for the change.
+   The verifier must report failures, flakes, missing coverage, and environment issues. Fix or
+   explicitly resolve every actionable finding before starting code review. If a verifier finding
+   requires a code change, rerun the verifier after addressing it.
+
+8. **Run `code-review` before every commit.** Invoke the `code-review` sub-agent against the current
+   branch diff and every staged, unstaged, and untracked file. The reviewer must act as an expert in
+   TypeScript, React, Next.js App Router, Tailwind CSS, Vitest, and Playwright. Address every
+   actionable finding before committing. If review findings cause changes, rerun the appropriate
+   tests and the `verifier`, then obtain a fresh `code-review` approval for the changed state.
+
+9. **Commit after approval.** Commit only after verification and code review are complete. Use
+   Conventional Commits:
+
+   ```text
+   <type>(<scope>): <imperative summary>
+   ```
+
+   Keep the subject at 72 characters or fewer, describe why in the body when useful, and do not
+   combine unrelated work.
+
+10. **Create pull requests from the reviewed state.**
+    - Confirm that local verification remains valid.
+    - Rerun `code-review` only if the reviewed state changed after the pre-commit review.
+    - A changed state includes code, tests, documentation, generated files, conflict resolution,
+      or any other staged, unstaged, or untracked content.
+    - Do not repeat code review when the already-reviewed diff and worktree remain unchanged.
+    - Push and create the pull request only after local verification and any required code review
+      are complete.
+    - Open a normal, ready-for-review pull request by default. Do not open draft pull requests unless
+      the user explicitly asks for a draft.
+
+11. **Merge only clean, passing pull requests.** Merge only after GitHub reports a clean merge state
+    and every configured check passes. Never bypass a failing or pending required check. Use squash
+    merge for short-lived development branches to keep `main` linear, then delete the merged branch.
+    - **Check for an assigned reviewer before merging.** After opening the pull request, check whether
+      a reviewer or team was assigned by repository rules, automation, or a human. Use `gh pr view
+      <n> --json reviewRequests,reviews` to see both pending requests and submitted reviews.
+    - **If a reviewer is assigned, wait for the review.** Do not merge a pull request that has a
+      review pending, even when every check is green. Address the feedback, push the fixes, and let
+      the reviewer see the updated state.
+    - Self-merges are allowed only when no reviewer is assigned and the conditions above are met.
+
+### Sub-agents
+
+Steps 6-8 use sub-agents defined in `.claude/agents/`:
+
+| Sub-agent | Role |
+| --- | --- |
+| `ui-review` | Web product design review: responsive layout, interaction, accessibility, and visual quality. |
+| `verifier` | Runs the repository validation gate and reports failures, flakes, and coverage gaps. |
+| `code-review` | Expert review of the branch diff and all uncommitted files. |
+
+**Invoke the `code-review` sub-agent, so the loop does not stall.** An agent's own review command may
+need the user to trigger it, which stops a workflow that should otherwise run unattended. Use the
+sub-agent and keep going. Either way, cover the scope step 8 asks for: the branch diff plus every
+staged, unstaged, and untracked file. Plain `git status --short` can collapse a new untracked
+directory to one entry, so use `--untracked-files=all` to see the files inside it.
+
+Agents that cannot invoke sub-agents must perform the equivalent work themselves and say so
+explicitly rather than skipping the step.
 
 ## Conventions
 


### PR DESCRIPTION
## What changed

- Add the required branch-first, thin-slice, TDD, complete-diff, verification, code-review, and reviewer-aware squash-merge lifecycle to `AGENTS.md`.
- Add project-specific `ui-review`, `verifier`, and `code-review` sub-agent definitions under `.claude/agents/`.
- Include `npm audit` in the documented full pre-PR gate and order the command to match `CI / validate`.

## Why

This aligns My First Commit's agent delivery workflow with the proven workflow in [Hilo's AGENTS.md](https://github.com/scottdensmore/hilo/blob/main/AGENTS.md), while replacing Windows/WinUI review criteria with this repository's Next.js, React, TypeScript, Tailwind, Vitest, Playwright, accessibility, and security concerns.

## Impact

Coding agents now follow one explicit end-to-end lifecycle and have concrete specialist reviewers they can invoke without pausing for manual commands. Application runtime behavior is unchanged.

## Validation

- UI review: no user-visible surface changed
- verifier: PASS
- code review: APPROVED, 0 findings
- `npm audit` (0 vulnerabilities)
- `npm test` (113 tests)
- `npm run test:e2e` against an isolated local server (17 tests)
- `npm run lint`
- `npm run format:check`
- `npm run check:agent-docs`
- `npm run check:labels`
- `npm run build`
- `npm ci --dry-run`
- `git diff --check`