### PR TITLE
fix(search): eliminate shared URL hydration mismatch

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -203,14 +203,16 @@ describe("Home", () => {
     });
   });
 
-  it("does not auto-search an invalid username from the URL", () => {
+  it("does not auto-search an invalid username from the URL", async () => {
     window.history.replaceState(null, "", "/?user=octo_cat");
 
     render(<Home />);
 
-    expect(mockGetCommits).not.toHaveBeenCalled();
-    expect(screen.getByRole("searchbox", { name: /github username/i })).toHaveValue("octo_cat");
+    await waitFor(() => {
+      expect(screen.getByRole("searchbox", { name: /github username/i })).toHaveValue("octo_cat");
+    });
     expect(screen.getByRole("status")).toHaveTextContent(/only letters, numbers, and hyphens/i);
+    expect(mockGetCommits).not.toHaveBeenCalled();
   });
 
   it("clears the shared URL when searching another user", async () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,8 +21,7 @@ const APP_RELEASE = process.env.NEXT_PUBLIC_APP_RELEASE ?? "local";
 const APP_RELEASE_URL = process.env.NEXT_PUBLIC_APP_RELEASE_URL ?? "";
 
 export default function Home() {
-  const [initialSharedUsername] = useState(getInitialSharedUsername);
-  const [username, setUsername] = useState(initialSharedUsername);
+  const [username, setUsername] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const {
     result,
@@ -48,14 +47,16 @@ export default function Home() {
   }, [result?.found]);
 
   useEffect(() => {
-    if (!initialSharedUsername) return;
+    const sharedUsername = getInitialSharedUsername();
+    if (!sharedUsername) return;
 
     const autoSearch = window.setTimeout(() => {
-      runSearch(initialSharedUsername);
+      setUsername(sharedUsername);
+      runSearch(sharedUsername);
     }, 0);
 
     return () => window.clearTimeout(autoSearch);
-  }, [initialSharedUsername, runSearch]);
+  }, [runSearch]);
 
   const handleClearRecentSearches = () => {
     clearRecentSearches();

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -30,6 +30,22 @@ async function searchForUsername(page: Page, username: string) {
   await page.getByRole("button", { name: "Search", exact: true }).click();
 }
 
+function captureReactRenderErrors(page: Page) {
+  const renderErrors: string[] = [];
+  const recordIfRenderError = (message: string) => {
+    if (/hydrat|server rendered HTML|minified React error #418/i.test(message)) {
+      renderErrors.push(message);
+    }
+  };
+
+  page.on("console", (message) => {
+    if (message.type() === "error") recordIfRenderError(message.text());
+  });
+  page.on("pageerror", (error) => renderErrors.push(error.message));
+
+  return renderErrors;
+}
+
 test("home page search field is keyboard-ready and not treated as a credential field", async ({
   page,
 }) => {
@@ -185,6 +201,18 @@ test("home page blocks invalid usernames without leaving keyboard flow", async (
   await expect(searchBox).toBeFocused();
 });
 
+test("invalid shared URLs hydrate cleanly and show validation", async ({ page }) => {
+  const renderErrors = captureReactRenderErrors(page);
+
+  await page.goto("/?user=octo_cat");
+
+  const searchBox = page.getByRole("searchbox", { name: "GitHub username" });
+  await expect(searchBox).toHaveValue("octo_cat");
+  await expect(page.getByRole("status")).toContainText("Use only letters, numbers, and hyphens.");
+  await expect(searchBox).toBeFocused();
+  expect(renderErrors).toEqual([]);
+});
+
 test("home page renders recent searches stored in the browser", async ({ page }) => {
   await page.addInitScript(() => {
     window.localStorage.setItem("my-first-commit:recent-searches", JSON.stringify(["octocat"]));
@@ -303,6 +331,19 @@ test.describe("local mocked commit search states", () => {
     isDeployedTarget,
     "mocked commit search states only run against the local Playwright server",
   );
+
+  test("valid shared URLs automatically render search results", async ({ page }) => {
+    const renderErrors = captureReactRenderErrors(page);
+
+    await page.goto("/?user=e2e-result");
+
+    await expect(page.getByRole("heading", { name: "First public commit found" })).toBeVisible();
+    await expect(
+      page.getByText(/earliest indexed public commit for @e2e-result appears in/i),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\?user=e2e-result$/);
+    expect(renderErrors).toEqual([]);
+  });
 
   test("home page renders result sharing and source context", async ({ context, page }) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);


### PR DESCRIPTION
## Summary

- make the server render and initial client render start from the same empty search state
- adopt and auto-search a shared `?user=` value after hydration
- add valid and invalid shared-URL journeys that fail on page errors and React hydration console errors

## Root cause

The state initializer read `window.location` in the browser but returned an empty value during server rendering. Invalid shared usernames therefore produced validation markup only on the initial client render, triggering React hydration error #418.

## Validation

- `npm audit` — 0 vulnerabilities
- `npm test` — 113/113 passed
- `npm run test:e2e` — 19/19 passed on an isolated local port
- `npm run lint`
- `npm run format:check`
- `npm run check:agent-docs`
- `npm run check:labels`
- `npm run build`
- required UI review, verifier, and code review all approved

Closes #96