### PR TITLE
fix(search): prevent stale overlapping results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,9 @@ npm audit && npm test && npm run test:e2e && npm run lint && npm run format:chec
 ## Gotchas
 
 - **E2E mocks.** `E2E_COMMIT_SEARCH_MOCKS=1` makes `app/actions.ts` return fixtures for the reserved
-  usernames `e2e-result`, `e2e-empty`, `e2e-rate-limit`, and `e2e-unavailable`. Playwright sets this
-  automatically and runs the app on port **3100**, not 3000. Add new fixture cases in `app/actions.ts`
-  when adding browser coverage for a new state.
+  usernames `e2e-result`, `e2e-slow-result`, `e2e-empty`, `e2e-rate-limit`, and
+  `e2e-unavailable`. Playwright sets this automatically and runs the app on port **3100**, not 3000.
+  Add new fixture cases in `app/actions.ts` when adding browser coverage for a new state.
 - **Prettier ignores `*.md`.** Prose is formatted by hand. Do not run the formatter over docs, and do
   not reflow markdown as part of an unrelated change.
 - **The commit cache is per-process.** It is a plain `Map`, so it resets on every serverless cold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ## Unreleased
 
+### Fixed
+
+- Prevented older overlapping searches from replacing newer results, and disabled search shortcuts while a request is pending.
+
 ### Changed
 
 - Removed the superseded specification and roadmap documents, along with their README links.

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -13,6 +13,7 @@ const octokit = new Octokit({
 
 const GITHUB_SEARCH_TIMEOUT_MS = 10_000;
 const E2E_COMMIT_SEARCH_MOCKS_ENABLED = process.env.E2E_COMMIT_SEARCH_MOCKS === "1";
+const E2E_SLOW_SEARCH_DELAY_MS = 750;
 const EMPTY_COMMIT_SEARCH_MESSAGE =
   "No public commits found for this user (or indexing is delayed).";
 
@@ -50,6 +51,7 @@ function getE2eCommitSearchResult(username: string): CommitData | null {
 
   switch (username) {
     case "e2e-result":
+    case "e2e-slow-result":
       return {
         found: true,
         commits: [
@@ -229,7 +231,12 @@ export async function getCommits(username: string): Promise<CommitData> {
   if (validationMessage) return commitSearchError(validationMessage, "validation");
 
   const e2eCommitSearchResult = getE2eCommitSearchResult(normalizedUsername);
-  if (e2eCommitSearchResult) return e2eCommitSearchResult;
+  if (e2eCommitSearchResult) {
+    if (normalizedUsername === "e2e-slow-result") {
+      await new Promise((resolve) => setTimeout(resolve, E2E_SLOW_SEARCH_DELAY_MS));
+    }
+    return e2eCommitSearchResult;
+  }
 
   const cacheKey = normalizedUsername.toLowerCase();
   const cachedCommitSearch = getCachedCommitSearch(cacheKey);

--- a/app/home/SearchErrorState.tsx
+++ b/app/home/SearchErrorState.tsx
@@ -47,6 +47,7 @@ export default function SearchErrorState({
           <SearchShortcutSection
             title="Examples"
             usernames={exampleUsernames}
+            isPending={isPending}
             onSearch={onExampleSearch}
             getButtonLabel={(username) => `@${username}`}
             buttonAriaLabel={(username) => `Search example username ${username}`}
@@ -67,7 +68,8 @@ export default function SearchErrorState({
         <button
           type="button"
           onClick={onReset}
-          className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-2 text-sm font-semibold text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+          disabled={isPending}
+          className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-2 text-sm font-semibold text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
         >
           Edit username
         </button>

--- a/app/home/SearchShortcutSection.tsx
+++ b/app/home/SearchShortcutSection.tsx
@@ -1,6 +1,7 @@
 type SearchShortcutSectionProps = {
   title: string;
   usernames: string[];
+  isPending: boolean;
   onSearch: (username: string) => void;
   getButtonLabel: (username: string) => string;
   buttonAriaLabel: (username: string) => string;
@@ -10,6 +11,7 @@ type SearchShortcutSectionProps = {
 export default function SearchShortcutSection({
   title,
   usernames,
+  isPending,
   onSearch,
   getButtonLabel,
   buttonAriaLabel,
@@ -20,6 +22,7 @@ export default function SearchShortcutSection({
   return (
     <section
       aria-labelledby={`${title.toLowerCase().replace(/\s+/g, "-")}-heading`}
+      aria-busy={isPending}
       className="mt-4 w-full max-w-md"
     >
       <div className="flex items-center justify-between gap-3">
@@ -33,8 +36,9 @@ export default function SearchShortcutSection({
           <button
             type="button"
             onClick={onClear}
+            disabled={isPending}
             aria-label="Clear recent searches"
-            className="rounded-sm text-xs font-medium text-[var(--github-gray-text)] hover:text-[var(--github-blue)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+            className="rounded-sm text-xs font-medium text-[var(--github-gray-text)] hover:text-[var(--github-blue)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
             Clear
           </button>
@@ -45,8 +49,9 @@ export default function SearchShortcutSection({
           <button
             key={username}
             type="button"
+            disabled={isPending}
             onClick={() => onSearch(username)}
-            className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+            className="inline-flex items-center justify-center rounded-md border border-[var(--github-border)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--github-gray-dark)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
             aria-label={buttonAriaLabel(username)}
           >
             {getButtonLabel(username)}

--- a/app/home/searchExecution.test.ts
+++ b/app/home/searchExecution.test.ts
@@ -26,12 +26,22 @@ const commit: CommitInfo = {
 
 const foundResult: CommitData = { found: true, commits: [commit] };
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
 // The real `startTransition` runs its callback in a React transition; the test
 // double runs it immediately and exposes the resulting promise so assertions
 // can await the async search work.
 function createHandlers() {
   let pending: Promise<unknown> | undefined;
   const handlers = {
+    isLatestSearch: vi.fn(() => true),
     startTransition: vi.fn((callback: () => unknown) => {
       pending = Promise.resolve(callback());
     }),
@@ -120,6 +130,62 @@ describe("runCommitSearch", () => {
       found: false,
       error_kind: "empty",
       commit_count: 0,
+    });
+  });
+
+  it("ignores an earlier search that resolves after the latest request", async () => {
+    const staleSearch = createDeferred<CommitData>();
+    const latestSearch = createDeferred<CommitData>();
+    const staleResult: CommitData = {
+      found: true,
+      commits: [{ ...commit, message: "Stale search result" }],
+    };
+    const latestResult: CommitData = {
+      found: true,
+      commits: [{ ...commit, message: "Latest search result" }],
+    };
+    vi.mocked(getCommits).mockImplementation((username) =>
+      username === "octocat" ? staleSearch.promise : latestSearch.promise,
+    );
+    const pendingSearches: Promise<unknown>[] = [];
+    const handlers = {
+      startTransition: vi.fn((callback: () => unknown) => {
+        pendingSearches.push(Promise.resolve(callback()));
+      }),
+      setLastSearchedUsername: vi.fn(),
+      setShareStatus: vi.fn(),
+      setResult: vi.fn(),
+      setRecentSearches: vi.fn(),
+    };
+    let latestSearchId = 0;
+    const startSearch = (username: string) => {
+      const searchId = ++latestSearchId;
+      runCommitSearch(
+        username,
+        {},
+        {
+          ...handlers,
+          isLatestSearch: () => searchId === latestSearchId,
+        },
+      );
+    };
+
+    startSearch("octocat");
+    startSearch("torvalds");
+    latestSearch.resolve(latestResult);
+    await pendingSearches[1];
+    staleSearch.resolve(staleResult);
+    await pendingSearches[0];
+
+    expect(handlers.setLastSearchedUsername).toHaveBeenLastCalledWith("torvalds");
+    expect(handlers.setResult).toHaveBeenCalledOnce();
+    expect(handlers.setResult).toHaveBeenCalledWith(latestResult);
+    expect(handlers.setRecentSearches).toHaveBeenCalledOnce();
+    expect(trackAppEvent).toHaveBeenCalledTimes(3);
+    expect(trackAppEvent).toHaveBeenLastCalledWith("search_completed", {
+      found: true,
+      error_kind: "none",
+      commit_count: 1,
     });
   });
 });

--- a/app/home/searchExecution.ts
+++ b/app/home/searchExecution.ts
@@ -8,6 +8,7 @@ import { saveStoredRecentSearches } from "./recentSearches";
 import { updateSharedSearchUrl } from "./sharedSearch";
 
 type SearchHandlers = {
+  isLatestSearch: () => boolean;
   startTransition: TransitionStartFunction;
   setLastSearchedUsername: Dispatch<SetStateAction<string>>;
   setShareStatus: Dispatch<SetStateAction<string>>;
@@ -19,6 +20,7 @@ export function runCommitSearch(
   searchUsername: string,
   options: { updateUrl?: boolean } = {},
   {
+    isLatestSearch,
     startTransition,
     setLastSearchedUsername,
     setShareStatus,
@@ -38,6 +40,8 @@ export function runCommitSearch(
   setShareStatus("");
   startTransition(async () => {
     const data = await getCommits(trimmedUsername);
+    if (!isLatestSearch()) return;
+
     setResult(data);
     trackAppEvent("search_completed", {
       found: data.found,

--- a/app/home/useCommitSearch.ts
+++ b/app/home/useCommitSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useTransition } from "react";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import type { CommitData } from "../commitTypes";
 import { clearStoredRecentSearches, getStoredRecentSearches } from "./recentSearches";
 import { runCommitSearch } from "./searchExecution";
@@ -17,6 +17,7 @@ export function useCommitSearch() {
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [shareStatus, setShareStatus] = useState("");
   const [isPending, startTransition] = useTransition();
+  const latestSearchIdRef = useRef(0);
 
   useEffect(() => {
     const loadRecentSearches = window.setTimeout(() => {
@@ -27,7 +28,10 @@ export function useCommitSearch() {
   }, []);
 
   const runSearch = useCallback((searchUsername: string, options: RunSearchOptions = {}) => {
+    const searchId = ++latestSearchIdRef.current;
+
     runCommitSearch(searchUsername, options, {
+      isLatestSearch: () => searchId === latestSearchIdRef.current,
       startTransition,
       setLastSearchedUsername,
       setShareStatus,

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Home from "./page";
 import { getCommits } from "./actions";
+import type { CommitData } from "./commitTypes";
 import { track } from "@vercel/analytics";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -16,7 +17,7 @@ vi.mock("@vercel/analytics", () => ({
 const mockGetCommits = vi.mocked(getCommits);
 const mockTrack = vi.mocked(track);
 
-const commitResult = {
+const commitResult: CommitData = {
   found: true,
   commits: [
     {
@@ -37,6 +38,15 @@ const commitResult = {
     },
   ],
 };
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
 
 describe("Home", () => {
   beforeEach(() => {
@@ -444,6 +454,49 @@ describe("Home", () => {
     resolveSearch(commitResult);
 
     await screen.findByRole("link", { name: "Initial commit" });
+  });
+
+  it("disables every search shortcut while a request is pending", async () => {
+    window.localStorage.setItem("my-first-commit:recent-searches", JSON.stringify(["octocat"]));
+    const pendingSearch = createDeferred<CommitData>();
+    mockGetCommits.mockReturnValue(pendingSearch.promise);
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.click(await screen.findByRole("button", { name: /search octocat again/i }));
+
+    expect(screen.getByRole("button", { name: /clear recent searches/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /search octocat again/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /search example username octocat/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /search example username torvalds/i }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /search example username gaearon/i })).toBeDisabled();
+
+    await act(async () => pendingSearch.resolve(commitResult));
+  });
+
+  it("disables editing the username while a retry is pending", async () => {
+    const pendingRetry = createDeferred<CommitData>();
+    mockGetCommits
+      .mockResolvedValueOnce({
+        found: false,
+        errorKind: "unavailable",
+        error: "GitHub is temporarily unavailable. Please try again soon.",
+        commits: [],
+      })
+      .mockReturnValueOnce(pendingRetry.promise);
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octocat");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    await user.click(await screen.findByRole("button", { name: /try again/i }));
+
+    expect(screen.getByRole("button", { name: /try again/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /edit username/i })).toBeDisabled();
+
+    await act(async () => pendingRetry.resolve(commitResult));
   });
 
   it("renders a helpful empty state when no public commits are found", async () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -166,6 +166,7 @@ export default function Home() {
           <SearchShortcutSection
             title="Recent searches"
             usernames={recentSearches}
+            isPending={isPending}
             onSearch={handleShortcutSearch}
             getButtonLabel={(recentUsername) => `@${recentUsername}`}
             buttonAriaLabel={(recentUsername) => `Search ${recentUsername} again`}
@@ -177,6 +178,7 @@ export default function Home() {
           <SearchShortcutSection
             title="Examples"
             usernames={EXAMPLE_USERNAMES}
+            isPending={isPending}
             onSearch={handleShortcutSearch}
             getButtonLabel={(exampleUsername) => `@${exampleUsername}`}
             buttonAriaLabel={(exampleUsername) => `Search example username ${exampleUsername}`}

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -345,6 +345,40 @@ test.describe("local mocked commit search states", () => {
     expect(renderErrors).toEqual([]);
   });
 
+  test("search shortcuts stay disabled while a request is pending", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "my-first-commit:recent-searches",
+        JSON.stringify(["e2e-slow-result", "e2e-result"]),
+      );
+    });
+    await page.goto("/");
+
+    const slowSearch = page.getByRole("button", { name: "Search e2e-slow-result again" });
+    const secondSearch = page.getByRole("button", { name: "Search e2e-result again" });
+    await slowSearch.click();
+
+    await expect(page.getByRole("button", { name: "Clear recent searches" })).toBeDisabled();
+    await expect(slowSearch).toBeDisabled();
+    await expect(secondSearch).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Search example username octocat" }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Search example username torvalds" }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Search example username gaearon" }),
+    ).toBeDisabled();
+
+    await secondSearch.evaluate((button: HTMLButtonElement) => button.click());
+    await expect(page).toHaveURL(/\?user=e2e-slow-result$/);
+    await expect(page.getByRole("heading", { name: "First public commit found" })).toBeVisible();
+    await expect(
+      page.getByText(/earliest indexed public commit for @e2e-slow-result appears in/i),
+    ).toBeVisible();
+  });
+
   test("home page renders result sharing and source context", async ({ context, page }) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     await searchForUsername(page, "e2e-result");


### PR DESCRIPTION
## Summary

- assign each initiated search an identity and ignore superseded completions
- prevent stale requests from updating results, recent searches, or completion analytics
- disable search shortcuts, recent-search clearing, retry editing, and other search entry points while work is pending
- add deterministic reverse-resolution unit coverage and a delayed browser fixture/journey

## Root cause

Every Server Action response was previously applied unconditionally. If two requests overlapped and the older request finished last, its commit data could replace the newer result while the URL and displayed username still identified the newer search. Pending shortcut and reset controls also allowed users to initiate conflicting state changes.

## User impact

The displayed username, shared URL, and commit data now remain consistent. Pending controls use native disabled behavior so users cannot accidentally start or undo conflicting work.

## Validation

- `npm audit` — 0 vulnerabilities
- `npm test` — 116/116 passed
- `npm run test:e2e` — 20/20 passed on an isolated local port
- `npm run lint`
- `npm run format:check`
- `npm run check:agent-docs`
- `npm run check:labels`
- `npm run build`
- required UI review, verifier, and code review approved the final state

Closes #97