### PR TITLE
docs(agents): clarify test execution ownership

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -7,7 +7,14 @@ tools: Read, Grep, Glob, Bash
 You verify that a change is safe to publish. Run commands and report evidence; do not fix code. Read
 `AGENTS.md` first for the current repository commands and environment notes.
 
-## What to run
+## Focused journey mode
+
+During TDD, the main agent may ask you to run one exact Playwright journey that it authored or
+changed. Run only that requested journey, establish the expected red or green result, and return a
+concise summary. Do not expand a focused request into the complete gate, and do not run focused unit
+tests that belong to the main agent. Focused journey results never replace final verification.
+
+## Final verification mode
 
 Run the complete CI-equivalent gate from the repository root:
 
@@ -22,8 +29,8 @@ npm run check:labels
 npm run build
 ```
 
-Use focused tests first when they make a failure easier to diagnose, but do not substitute them for
-the full gate. Treat warnings introduced by the branch as findings. If a failure looks flaky or
+Use focused tests when they make a failure easier to diagnose, but do not substitute them for the
+full gate. Treat warnings introduced by the branch as findings. If a failure looks flaky or
 environment-specific, rerun the smallest command that can distinguish a real regression from an
 environment problem and report both results.
 
@@ -39,6 +46,10 @@ pure typing, and configuration-only changes may need no new test; state when tha
 For each finding give its **category** (`audit-failure`, `test-failure`, `build-failure`, `warning`,
 `flake`, `missing-coverage`, or `environment`), relevant command output, `file:line` when known, and
 whether the author can act on it.
+
+Keep reports concise so command output does not spill into the main agent's context. Summarize
+successful commands with counts or outcomes. For failures, include only the smallest useful excerpt
+unless the main agent asks for full logs.
 
 End with **PASS** only when every required command actually succeeded and there are no actionable
 findings. Otherwise end with **FAIL** and the actionable finding count. Never infer that an unrun

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,11 +79,18 @@ npm audit && npm test && npm run test:e2e && npm run lint && npm run format:chec
    quick rollback.
 
 4. **Use test-driven development when behavior or structure is testable.**
-   - Add or update a focused test before implementation.
-   - Run it and confirm it fails for the expected reason.
+   - The main agent adds or updates a focused test before implementation.
+   - For unit coverage, the main agent runs only the exact test it authored or changed, filtered by
+     file and test name, and confirms that it fails for the expected reason.
+   - For user-journey coverage, the main agent authors the focused Playwright test and invokes the
+     `verifier` to run that exact journey and report the expected failure concisely.
    - Implement the smallest appropriate change.
-   - Run focused tests while iterating.
+   - Repeat the same focused unit test in the main agent and focused journey in the `verifier` until
+     each passes. Do not substitute focused checks for the complete verification gate in step 7.
    - Refactor only while the relevant tests remain green.
+   - The main agent must not run whole test files or suites, Playwright, dependency audits, lint,
+     formatting checks, agent-document or label checks, or production builds. Those commands belong
+     to the `verifier`, keeping routine command output out of the main implementation context.
 
 5. **Inspect the complete diff.** Review the branch diff plus all staged, unstaged, and untracked
    files. Remove accidental or unrelated changes while preserving work that belongs to the user.
@@ -94,16 +101,20 @@ npm audit && npm test && npm run test:e2e && npm run lint && npm run format:chec
    should say so and return without inventing findings.
 
 7. **Run `verifier` before code review.** Invoke the `verifier` sub-agent to run the dependency
-   audit, tests, static checks, production build, and journey coverage appropriate for the change.
-   The verifier must report failures, flakes, missing coverage, and environment issues. Fix or
-   explicitly resolve every actionable finding before starting code review. If a verifier finding
-   requires a code change, rerun the verifier after addressing it.
+   audit, complete unit and Playwright suites, static checks, production build, and journey coverage
+   appropriate for the change. Focused Playwright runs performed during TDD do not replace this
+   complete pass. The verifier must report successes concisely and include only the failure evidence
+   needed to diagnose failures, flakes, missing coverage, and environment issues. Fix or explicitly
+   resolve every actionable finding before starting code review. If a verifier finding requires a
+   code change, the main agent reruns only the exact affected unit regressions, the verifier reruns
+   affected focused journeys when needed, and then the verifier reruns the complete gate.
 
 8. **Run `code-review` before every commit.** Invoke the `code-review` sub-agent against the current
    branch diff and every staged, unstaged, and untracked file. The reviewer must act as an expert in
    TypeScript, React, Next.js App Router, Tailwind CSS, Vitest, and Playwright. Address every
-   actionable finding before committing. If review findings cause changes, rerun the appropriate
-   tests and the `verifier`, then obtain a fresh `code-review` approval for the changed state.
+   actionable finding before committing. If review findings cause changes, the main agent reruns
+   only the exact affected unit regressions, then the `verifier` reruns any affected focused journeys
+   and the complete gate before a fresh `code-review` approval for the changed state.
 
 9. **Commit after approval.** Commit only after verification and code review are complete. Use
    Conventional Commits:
@@ -144,7 +155,7 @@ Steps 6-8 use sub-agents defined in `.claude/agents/`:
 | Sub-agent | Role |
 | --- | --- |
 | `ui-review` | Web product design review: responsive layout, interaction, accessibility, and visual quality. |
-| `verifier` | Runs the repository validation gate and reports failures, flakes, and coverage gaps. |
+| `verifier` | Runs focused Playwright journeys during TDD, then the complete repository validation gate, and reports concise evidence. |
 | `code-review` | Expert review of the branch diff and all uncommitted files. |
 
 **Invoke the `code-review` sub-agent, so the loop does not stall.** An agent's own review command may

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Changed
 
+- Clarified that the main agent owns exact unit-test red/green loops while the verifier owns focused Playwright execution and the complete validation gate.
 - Removed the superseded specification and roadmap documents, along with their README links.
 - Upgraded the project from Node 22 to Node 24, the current Active LTS and Vercel's default runtime. `.nvmrc`, `package.json` engines, and the docs now all name 24. Node 26 is deliberately not used: Vercel offers only 20.x, 22.x, and 24.x, so pinning 26 would not deploy.
 


### PR DESCRIPTION
## Summary

- assign exact unit-test red/green execution to the main agent
- assign focused Playwright red/green execution and the complete final gate to the verifier
- require concise verifier reporting so routine command output stays out of the main implementation context
- clarify rerun ownership after verifier or code-review findings
- align the verifier sub-agent definition and changelog with the canonical workflow

## Why

The previous workflow required focused TDD and full verification but did not explicitly say which agent should execute each layer. That ambiguity could duplicate expensive checks and pollute the main agent's implementation context with full-suite output.

## Validation

The verifier ran the complete repository gate:

- `npm audit` — 0 vulnerabilities
- `npm test` — 116/116 passed
- `npm run test:e2e` — 20/20 passed
- `npm run lint`
- `npm run format:check`
- `npm run check:agent-docs`
- `npm run check:labels`
- `npm run build`
- UI review and code review approved the exact final state

No tests were added because this is a documentation-only workflow clarification.