### PR TITLE
fix(search): normalize Server Action rejections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,10 @@ npm audit && npm test && npm run test:e2e && npm run lint && npm run format:chec
 ## Gotchas
 
 - **E2E mocks.** `E2E_COMMIT_SEARCH_MOCKS=1` makes `app/actions.ts` return fixtures for the reserved
-  usernames `e2e-result`, `e2e-slow-result`, `e2e-empty`, `e2e-rate-limit`, and
-  `e2e-unavailable`. Playwright sets this automatically and runs the app on port **3100**, not 3000.
-  Add new fixture cases in `app/actions.ts` when adding browser coverage for a new state.
+  usernames `e2e-result`, `e2e-slow-result`, `e2e-reject-once-*`, `e2e-empty`,
+  `e2e-rate-limit`, and `e2e-unavailable`. Playwright sets this automatically and runs the app on
+  port **3100**, not 3000. Add new fixture cases in `app/actions.ts` when adding browser coverage for
+  a new state.
 - **Prettier ignores `*.md`.** Prose is formatted by hand. Do not run the formatter over docs, and do
   not reflow markdown as part of an unrelated change.
 - **The commit cache is per-process.** It is a plain `Map`, so it resets on every serverless cold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Fixed
 
+- Unexpected Server Action rejections now use the inline retry experience instead of escaping to the global error screen.
 - Prevented older overlapping searches from replacing newer results, and disabled search shortcuts while a request is pending.
 
 ### Changed

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -14,6 +14,8 @@ const octokit = new Octokit({
 const GITHUB_SEARCH_TIMEOUT_MS = 10_000;
 const E2E_COMMIT_SEARCH_MOCKS_ENABLED = process.env.E2E_COMMIT_SEARCH_MOCKS === "1";
 const E2E_SLOW_SEARCH_DELAY_MS = 750;
+const E2E_REJECT_ONCE_USERNAME_PREFIX = "e2e-reject-once-";
+const e2eRejectedUsernames = new Set<string>();
 const EMPTY_COMMIT_SEARCH_MESSAGE =
   "No public commits found for this user (or indexing is delayed).";
 
@@ -49,26 +51,31 @@ function getE2eCommitSearchResult(username: string): CommitData | null {
     },
   };
 
-  switch (username) {
-    case "e2e-result":
-    case "e2e-slow-result":
-      return {
-        found: true,
-        commits: [
-          mockCommit,
-          {
-            ...mockCommit,
-            message: "Follow-up commit",
-            html_url: "https://github.com/e2e-user/next-repo/commit/bcdefa234567",
-            sha: "bcdefa234567",
-            repository: {
-              name: "next-repo",
-              owner: "e2e-user",
-              full_name: "e2e-user/next-repo",
-            },
+  if (
+    username === "e2e-result" ||
+    username === "e2e-slow-result" ||
+    username.startsWith(E2E_REJECT_ONCE_USERNAME_PREFIX)
+  ) {
+    return {
+      found: true,
+      commits: [
+        mockCommit,
+        {
+          ...mockCommit,
+          message: "Follow-up commit",
+          html_url: "https://github.com/e2e-user/next-repo/commit/bcdefa234567",
+          sha: "bcdefa234567",
+          repository: {
+            name: "next-repo",
+            owner: "e2e-user",
+            full_name: "e2e-user/next-repo",
           },
-        ],
-      };
+        },
+      ],
+    };
+  }
+
+  switch (username) {
     case "e2e-empty":
       return commitSearchError(EMPTY_COMMIT_SEARCH_MESSAGE, "empty");
     case "e2e-rate-limit":
@@ -229,6 +236,15 @@ export async function getCommits(username: string): Promise<CommitData> {
 
   const validationMessage = getUsernameValidationMessage(normalizedUsername);
   if (validationMessage) return commitSearchError(validationMessage, "validation");
+
+  if (
+    E2E_COMMIT_SEARCH_MOCKS_ENABLED &&
+    normalizedUsername.startsWith(E2E_REJECT_ONCE_USERNAME_PREFIX) &&
+    !e2eRejectedUsernames.has(normalizedUsername)
+  ) {
+    e2eRejectedUsernames.add(normalizedUsername);
+    throw new Error("Synthetic E2E Server Action rejection");
+  }
 
   const e2eCommitSearchResult = getE2eCommitSearchResult(normalizedUsername);
   if (e2eCommitSearchResult) {

--- a/app/home/searchExecution.test.ts
+++ b/app/home/searchExecution.test.ts
@@ -133,6 +133,31 @@ describe("runCommitSearch", () => {
     });
   });
 
+  it("normalizes unexpected Server Action rejections as retryable unknown errors", async () => {
+    vi.mocked(getCommits).mockRejectedValue(
+      new Error("Sensitive upstream detail: q=author:octocat&token=secret"),
+    );
+    const { handlers, settle } = createHandlers();
+
+    runCommitSearch("octocat", {}, handlers);
+
+    await expect(settle()).resolves.toBeUndefined();
+    expect(handlers.setResult).toHaveBeenCalledWith({
+      found: false,
+      error: "GitHub commit search failed. Please try again.",
+      errorKind: "unknown",
+      commits: [],
+    });
+    expect(handlers.setRecentSearches).not.toHaveBeenCalled();
+    expect(trackAppEvent).toHaveBeenLastCalledWith("search_completed", {
+      found: false,
+      error_kind: "unknown",
+      commit_count: 0,
+    });
+    expect(JSON.stringify(handlers.setResult.mock.calls)).not.toContain("octocat");
+    expect(JSON.stringify(handlers.setResult.mock.calls)).not.toContain("secret");
+  });
+
   it("ignores an earlier search that resolves after the latest request", async () => {
     const staleSearch = createDeferred<CommitData>();
     const latestSearch = createDeferred<CommitData>();

--- a/app/home/searchExecution.ts
+++ b/app/home/searchExecution.ts
@@ -16,6 +16,15 @@ type SearchHandlers = {
   setRecentSearches: Dispatch<SetStateAction<string[]>>;
 };
 
+function unexpectedSearchError(): CommitData {
+  return {
+    found: false,
+    error: "GitHub commit search failed. Please try again.",
+    errorKind: "unknown",
+    commits: [],
+  };
+}
+
 export function runCommitSearch(
   searchUsername: string,
   options: { updateUrl?: boolean } = {},
@@ -39,7 +48,12 @@ export function runCommitSearch(
   setLastSearchedUsername(trimmedUsername);
   setShareStatus("");
   startTransition(async () => {
-    const data = await getCommits(trimmedUsername);
+    let data: CommitData;
+    try {
+      data = await getCommits(trimmedUsername);
+    } catch {
+      data = unexpectedSearchError();
+    }
     if (!isLatestSearch()) return;
 
     setResult(data);

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -445,4 +445,39 @@ test.describe("local mocked commit search states", () => {
     await expect(page.getByText(/temporary service error/i)).toBeVisible();
     await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
   });
+
+  test("home page recovers from an unexpected Server Action rejection", async ({
+    page,
+  }, testInfo) => {
+    const rejectionUsername = `e2e-reject-once-${testInfo.workerIndex}-${Date.now().toString(36)}`;
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await searchForUsername(page, rejectionUsername);
+
+    await expect(
+      page.getByRole("heading", { name: "We could not complete that search." }),
+    ).toBeVisible();
+    await expect(page.locator('main [role="alert"]')).toContainText(
+      "GitHub commit search failed. Please try again.",
+    );
+    await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          JSON.parse(window.localStorage.getItem("my-first-commit:recent-searches") ?? "[]"),
+        ),
+      )
+      .toEqual([]);
+
+    await page.getByRole("button", { name: "Try again" }).click();
+
+    await expect(page.getByRole("heading", { name: "First public commit found" })).toBeVisible();
+    await expect(
+      page.getByText(
+        new RegExp(`earliest indexed public commit for @${rejectionUsername} appears in`, "i"),
+      ),
+    ).toBeVisible();
+    expect(pageErrors).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

- normalize unexpected Server Action rejections into the existing inline unknown-error state
- keep rejected searches out of recent-search storage and emit only sanitized `unknown` analytics
- add focused unit and browser coverage for rejection, retry, recovery, and fixture determinism
- document the new E2E reject-once fixture

## Root cause

`runCommitSearch` awaited the Server Action without handling transport or runtime rejections. Those failures escaped the designed inline recovery flow and could reach the global error screen.

## Validation

- dependency audit: 0 vulnerabilities
- unit tests: 117/117
- Playwright: 21/21
- repeated reject/retry journey: 2/2 in one server process
- lint and Prettier
- agent-document and label checks
- production build and TypeScript
- UI review and code review: approved with zero findings

Closes #98