### PR TITLE
fix(actions): reject commits without valid dates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,10 @@ npm audit && npm test && npm run test:e2e && npm run lint && npm run format:chec
 ## Gotchas
 
 - **E2E mocks.** `E2E_COMMIT_SEARCH_MOCKS=1` makes `app/actions.ts` return fixtures for the reserved
-  usernames `e2e-result`, `e2e-slow-result`, `e2e-reject-once-*`, `e2e-empty`,
-  `e2e-rate-limit`, and `e2e-unavailable`. Playwright sets this automatically and runs the app on
-  port **3100**, not 3000. Add new fixture cases in `app/actions.ts` when adding browser coverage for
-  a new state.
+  usernames `e2e-result`, `e2e-slow-result`, `e2e-reject-once-*`, `e2e-malformed-dates`,
+  `e2e-empty`, `e2e-rate-limit`, and `e2e-unavailable`. Playwright sets this automatically and runs
+  the app on port **3100**, not 3000. Add new fixture cases in `app/actions.ts` when adding browser
+  coverage for a new state.
 - **Prettier ignores `*.md`.** Prose is formatted by hand. Do not run the formatter over docs, and do
   not reflow markdown as part of an unrelated change.
 - **The commit cache is per-process.** It is a plain `Map`, so it resets on every serverless cold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Fixed
 
+- Commit results with missing or invalid dates no longer crash the result timeline.
 - Unexpected Server Action rejections now use the inline retry experience instead of escaping to the global error screen.
 - Prevented older overlapping searches from replacing newer results, and disabled search shortcuts while a request is pending.
 

--- a/app/actions.test.ts
+++ b/app/actions.test.ts
@@ -185,6 +185,89 @@ describe("getCommits", () => {
     });
   });
 
+  it("falls back to a parseable author date when the committer date is invalid", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [
+          {
+            ...commitItem,
+            commit: {
+              ...commitItem.commit,
+              committer: {
+                date: "not-a-date",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getCommits("octo");
+
+    expect(result.commits[0].date).toBe("2024-01-01T00:00:00Z");
+  });
+
+  it("skips commit items without a parseable date while keeping valid results", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [
+          {
+            ...commitItem,
+            commit: {
+              ...commitItem.commit,
+              author: null,
+              committer: null,
+            },
+          },
+          commitItem,
+        ],
+      },
+    });
+
+    const result = await getCommits("octo");
+
+    expect(result.found).toBe(true);
+    expect(result.commits).toHaveLength(1);
+    expect(result.commits[0].sha).toBe("abcdef123456");
+    expect(console.warn).toHaveBeenCalledWith({
+      event: "github_commit_search_malformed_item",
+      itemIndex: 0,
+    });
+  });
+
+  it("returns an empty state when every commit date is missing, empty, or invalid", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [
+          {
+            ...commitItem,
+            commit: {
+              ...commitItem.commit,
+              author: null,
+              committer: null,
+            },
+          },
+          {
+            ...commitItem,
+            commit: {
+              ...commitItem.commit,
+              author: { date: "" },
+              committer: { date: "not-a-date" },
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(getCommits("octo")).resolves.toEqual({
+      found: false,
+      error: "No public commits found for this user (or indexing is delayed).",
+      errorKind: "empty",
+      commits: [],
+    });
+    expect(console.warn).toHaveBeenCalledTimes(2);
+  });
+
   it("returns a friendly empty state when no indexed commits are found", async () => {
     searchCommits.mockResolvedValue({
       data: {

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -75,6 +75,27 @@ function getE2eCommitSearchResult(username: string): CommitData | null {
     };
   }
 
+  if (username === "e2e-malformed-dates") {
+    return {
+      found: true,
+      commits: [
+        mockCommit,
+        {
+          ...mockCommit,
+          message: "Commit with malformed date",
+          date: "not-a-date",
+          html_url: "https://github.com/e2e-user/next-repo/commit/bcdefa234567",
+          sha: "bcdefa234567",
+          repository: {
+            name: "next-repo",
+            owner: "e2e-user",
+            full_name: "e2e-user/next-repo",
+          },
+        },
+      ],
+    };
+  }
+
   switch (username) {
     case "e2e-empty":
       return commitSearchError(EMPTY_COMMIT_SEARCH_MESSAGE, "empty");
@@ -158,6 +179,11 @@ function withTimeoutSignal<T>(callback: (signal: AbortSignal) => Promise<T>) {
     .finally(() => clearTimeout(timeout));
 }
 
+function parseableDate(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  return Number.isNaN(Date.parse(value)) ? null : value;
+}
+
 function mapCommitItem(item: unknown, username: string): CommitInfo | null {
   if (typeof item !== "object" || item === null) return null;
 
@@ -202,18 +228,16 @@ function mapCommitItem(item: unknown, username: string): CommitInfo | null {
 
   const authorDate = candidate.commit?.author?.date;
   const committerDate = candidate.commit?.committer?.date;
+  const date = parseableDate(committerDate) ?? parseableDate(authorDate);
   const authorLogin = candidate.author?.login;
   const authorAvatarUrl = candidate.author?.avatar_url;
   const authorHtmlUrl = candidate.author?.html_url;
 
+  if (!date) return null;
+
   return {
     message,
-    date:
-      typeof committerDate === "string"
-        ? committerDate
-        : typeof authorDate === "string"
-          ? authorDate
-          : "",
+    date,
     html_url: htmlUrl,
     sha,
     repository: {

--- a/components/FirstCommitDisplay.test.tsx
+++ b/components/FirstCommitDisplay.test.tsx
@@ -57,4 +57,12 @@ describe("FirstCommitDisplay", () => {
     expect(container.firstElementChild).toHaveClass("max-w-xl");
     expect(screen.queryByText(/commit date/i)).not.toBeInTheDocument();
   });
+
+  it("renders a date-unavailable fallback instead of throwing for a malformed date", () => {
+    expect(() =>
+      render(<FirstCommitDisplay data={{ ...commit, date: "not-a-date" }} />),
+    ).not.toThrow();
+
+    expect(screen.getAllByText("Date unavailable")).not.toHaveLength(0);
+  });
 });

--- a/components/FirstCommitDisplay.tsx
+++ b/components/FirstCommitDisplay.tsx
@@ -27,7 +27,8 @@ function formatCommitDateTime(date: Date) {
 }
 
 export default function FirstCommitDisplay({ data, isMain = true }: FirstCommitDisplayProps) {
-  const dateObj = new Date(data.date);
+  const parsedDate = new Date(data.date);
+  const dateObj = Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
   const widthClass = isMain ? "max-w-2xl" : "max-w-xl";
   const shortSha = data.sha.substring(0, 7);
   const [commitSubject, ...commitBodyLines] = data.message.split("\n");
@@ -100,21 +101,31 @@ export default function FirstCommitDisplay({ data, isMain = true }: FirstCommitD
                 {data.author.login}
               </a>
               <span>committed</span>
-              <time dateTime={data.date} title={formatCommitDateTime(dateObj)}>
-                {formatDistanceToNow(dateObj, { addSuffix: true })}
-              </time>
+              {dateObj ? (
+                <time dateTime={data.date} title={formatCommitDateTime(dateObj)}>
+                  {formatDistanceToNow(dateObj, { addSuffix: true })}
+                </time>
+              ) : (
+                <span>Date unavailable</span>
+              )}
             </div>
             {isMain && (
               <dl className="mt-4 grid gap-2 text-xs text-[var(--github-gray-text)] sm:grid-cols-3">
                 <div className="rounded-md border border-[var(--github-border)] bg-[var(--github-gray-light)] px-3 py-2">
                   <dt className="font-semibold text-[var(--github-gray-dark)]">Commit date</dt>
                   <dd className="mt-1">
-                    <time dateTime={data.date}>{formatCommitDate(dateObj)}</time>
+                    {dateObj ? (
+                      <time dateTime={data.date}>{formatCommitDate(dateObj)}</time>
+                    ) : (
+                      "Date unavailable"
+                    )}
                   </dd>
                 </div>
                 <div className="rounded-md border border-[var(--github-border)] bg-[var(--github-gray-light)] px-3 py-2">
                   <dt className="font-semibold text-[var(--github-gray-dark)]">Commit age</dt>
-                  <dd className="mt-1">{formatDistanceToNow(dateObj, { addSuffix: false })}</dd>
+                  <dd className="mt-1">
+                    {dateObj ? formatDistanceToNow(dateObj, { addSuffix: false }) : "Unavailable"}
+                  </dd>
                 </div>
                 <div className="rounded-md border border-[var(--github-border)] bg-[var(--github-gray-light)] px-3 py-2">
                   <dt className="font-semibold text-[var(--github-gray-dark)]">

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -405,6 +405,19 @@ test.describe("local mocked commit search states", () => {
     await expect(page.getByRole("status")).toContainText("Result copied.");
   });
 
+  test("mixed valid and malformed commit dates render without crashing", async ({ page }) => {
+    const renderErrors = captureReactRenderErrors(page);
+
+    await searchForUsername(page, "e2e-malformed-dates");
+
+    await expect(page.getByRole("heading", { name: "First public commit found" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Initial public commit" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Commit with malformed date" })).toBeVisible();
+    await expect(page.getByText("Date unavailable")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Something went wrong." })).toHaveCount(0);
+    expect(renderErrors).toEqual([]);
+  });
+
   test("home page renders a helpful empty search state", async ({ page }) => {
     await searchForUsername(page, "e2e-empty");
 


### PR DESCRIPTION
## Summary

- require a parseable committer date or author-date fallback when mapping GitHub results
- skip malformed items with sanitized index-only logging and return the normal empty state when none remain
- render a defensive `Date unavailable` fallback if invalid data ever reaches the timeline
- add unit and browser coverage for fallback, mixed, all-invalid, and global-error prevention paths

## Root cause

GitHub search items without usable author or committer dates were mapped to an empty or invalid date string. The result component passed that value into `Intl` and `date-fns`, which could throw `RangeError: Invalid time value` and replace the search result with the global error screen.

## Validation

- dependency audit: 0 vulnerabilities
- unit tests: 121/121
- Playwright: 22/22
- lint and Prettier
- agent-document and label checks
- production build and TypeScript
- UI review and code review: approved with zero findings

Closes #99