### PR TITLE
fix(actions): validate runtime input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Fixed
 
+- Forged Server Action requests with non-string usernames now return validation errors safely.
 - Commit results with missing or invalid dates no longer crash the result timeline.
 - Unexpected Server Action rejections now use the inline retry experience instead of escaping to the global error screen.
 - Prevented older overlapping searches from replacing newer results, and disabled search shortcuts while a request is pending.

--- a/app/actions.test.ts
+++ b/app/actions.test.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearCommitSearchCache } from "./commitSearchCache";
 import { getCommits } from "./actions";
 
+const invokeGetCommits = getCommits as unknown as (
+  username: unknown,
+) => ReturnType<typeof getCommits>;
+
 const { searchCommits } = vi.hoisted(() => ({
   searchCommits: vi.fn(),
 }));
@@ -64,6 +68,26 @@ describe("getCommits", () => {
       commits: [],
     });
     expect(searchCommits).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["null", null],
+    ["array", []],
+    ["object", {}],
+    ["number", 42],
+    ["true boolean", true],
+    ["false boolean", false],
+    ["duck-typed object", { trim: () => "octo" }],
+  ])("returns a validation error for hostile %s Server Action input", async (_label, input) => {
+    await expect(invokeGetCommits(input)).resolves.toEqual({
+      found: false,
+      error: "Username is required",
+      errorKind: "validation",
+      commits: [],
+    });
+    expect(searchCommits).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("queries GitHub for the earliest commits by author", async () => {

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -255,7 +255,12 @@ function mapCommitItem(item: unknown, username: string): CommitInfo | null {
 }
 
 export async function getCommits(username: string): Promise<CommitData> {
-  const normalizedUsername = normalizeGitHubUsername(username);
+  const runtimeInput: unknown = username;
+  if (typeof runtimeInput !== "string") {
+    return commitSearchError("Username is required", "validation");
+  }
+
+  const normalizedUsername = normalizeGitHubUsername(runtimeInput);
   if (!normalizedUsername) return commitSearchError("Username is required", "validation");
 
   const validationMessage = getUsernameValidationMessage(normalizedUsername);


### PR DESCRIPTION
## Summary

- validate the Server Action username as a real runtime string before normalization
- return the established validation result for forged non-string requests
- preserve the string-only TypeScript signature for normal client callers
- add parameterized coverage for null, arrays, objects, numbers, booleans, and a duck-typed object

## Root cause

The exported action relied on its TypeScript `string` annotation, which does not validate serialized runtime input. A forged value could throw in `.trim()` or use a duck-typed `trim` method to reach cache and GitHub behavior.

## Validation

- dependency audit: 0 vulnerabilities
- unit tests: 128/128
- Playwright: 22/22
- lint and Prettier
- agent-document and label checks
- production build and TypeScript
- UI review: no rendered surface
- code review: approved with zero findings

Closes #100