### PR TITLE
fix(privacy): redact usernames from analytics URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Fixed
 
+- Vercel Analytics event URLs now remove shared-search usernames while preserving unrelated query parameters.
 - Forged Server Action requests with non-string usernames now return validation errors safely.
 - Commit results with missing or invalid dates no longer crash the result timeline.
 - Unexpected Server Action rejections now use the inline retry experience instead of escaping to the global error screen.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The app is a Next.js App Router project. The browser collects a GitHub username,
 - Usernames entered into the search field are sent to GitHub to retrieve public commit data.
 - `GITHUB_TOKEN` is used only server-side and is never exposed to the browser.
 - Recent searches are stored only in the user's browser under `my-first-commit:recent-searches`.
-- Vercel Analytics records page views and privacy-safe product events; analytics events do not include searched usernames.
+- Before Vercel Analytics receives page views or product events, the app removes the shared-search `user` query parameter; event properties do not include searched usernames.
 - The app does not store searches on a server.
 
 ## Limitations

--- a/app/PrivacySafeAnalytics.test.tsx
+++ b/app/PrivacySafeAnalytics.test.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import { Analytics } from "@vercel/analytics/next";
+import { describe, expect, it, vi } from "vitest";
+import { redactAnalyticsEvent } from "./home/analytics";
+import PrivacySafeAnalytics from "./PrivacySafeAnalytics";
+
+vi.mock("@vercel/analytics/next", () => ({
+  Analytics: vi.fn(() => null),
+}));
+
+describe("PrivacySafeAnalytics", () => {
+  it("registers URL redaction for every Vercel Analytics event", () => {
+    render(<PrivacySafeAnalytics />);
+
+    expect(vi.mocked(Analytics).mock.calls[0]?.[0]).toEqual({
+      beforeSend: redactAnalyticsEvent,
+    });
+  });
+});

--- a/app/PrivacySafeAnalytics.tsx
+++ b/app/PrivacySafeAnalytics.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { Analytics } from "@vercel/analytics/next";
+import { redactAnalyticsEvent } from "./home/analytics";
+
+export default function PrivacySafeAnalytics() {
+  return <Analytics beforeSend={redactAnalyticsEvent} />;
+}

--- a/app/home/analytics.test.ts
+++ b/app/home/analytics.test.ts
@@ -1,6 +1,6 @@
 import { track } from "@vercel/analytics";
 import { describe, expect, it, vi } from "vitest";
-import { trackAppEvent } from "./analytics";
+import { redactAnalyticsEvent, trackAppEvent } from "./analytics";
 
 vi.mock("@vercel/analytics", () => ({
   track: vi.fn(),
@@ -13,5 +13,30 @@ describe("trackAppEvent", () => {
     });
 
     expect(() => trackAppEvent("search_submitted")).not.toThrow();
+  });
+});
+
+describe("redactAnalyticsEvent", () => {
+  it.each([
+    {
+      event: {
+        type: "pageview" as const,
+        url: "https://example.com/?user=octo%20cat&ref=homepage#results",
+      },
+      expectedUrl: "https://example.com/?ref=homepage#results",
+    },
+    {
+      event: {
+        type: "event" as const,
+        url: "https://example.com/search?campaign=launch&user=octo%2Dcat&user=second",
+      },
+      expectedUrl: "https://example.com/search?campaign=launch",
+    },
+  ])("removes usernames from $event.type analytics URLs", ({ event, expectedUrl }) => {
+    expect(redactAnalyticsEvent(event)).toEqual({
+      ...event,
+      url: expectedUrl,
+    });
+    expect(event.url).toContain("user=");
   });
 });

--- a/app/home/analytics.ts
+++ b/app/home/analytics.ts
@@ -1,6 +1,17 @@
 import { track } from "@vercel/analytics";
+import type { BeforeSendEvent } from "@vercel/analytics/next";
 
 type AppEventProperties = Record<string, string | number | boolean>;
+
+export function redactAnalyticsEvent(event: BeforeSendEvent): BeforeSendEvent {
+  const url = new URL(event.url);
+  url.searchParams.delete("user");
+
+  return {
+    ...event,
+    url: url.toString(),
+  };
+}
 
 export function trackAppEvent(name: string, properties?: AppEventProperties) {
   try {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { Analytics } from "@vercel/analytics/next";
+import PrivacySafeAnalytics from "./PrivacySafeAnalytics";
 import "./globals.css";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
@@ -68,7 +68,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {children}
-        <Analytics />
+        <PrivacySafeAnalytics />
       </body>
     </html>
   );

--- a/app/privacy/page.test.tsx
+++ b/app/privacy/page.test.tsx
@@ -12,7 +12,7 @@ describe("PrivacyPage", () => {
     expect(screen.getByText(/my-first-commit:recent-searches/i)).toBeInTheDocument();
     expect(screen.getByText(/short-lived memory cache/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/analytics events do not include the searched GitHub username/i),
+      screen.getByText(/removes the shared-search user query parameter before analytics events/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/never sent to the browser/i)).toBeInTheDocument();
   });

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -50,8 +50,9 @@ export default function PrivacyPage() {
           <h2 className="text-xl font-semibold">Analytics</h2>
           <p className="mt-3 leading-7 text-[var(--github-gray-text)]">
             The app uses Vercel Analytics for basic product health signals, such as page views,
-            search completions, result counts, and error categories. Analytics events do not include
-            the searched GitHub username.
+            search completions, result counts, and error categories. The app removes the
+            shared-search user query parameter before analytics events are sent, and event
+            properties do not include the searched GitHub username.
           </p>
         </section>
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -105,7 +105,10 @@ test("privacy page documents search and analytics handling", async ({ page }) =>
     page.getByText(/usernames entered into the search form are sent to GitHub/i),
   ).toBeVisible();
   await expect(
-    page.getByText(/analytics events do not include the searched GitHub username/i),
+    page.getByText(/removes the shared-search user query parameter before analytics events/i),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/event properties do not include the searched GitHub username/i),
   ).toBeVisible();
   await expect(page.getByText(/never sent to the browser/i)).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- redact every shared-search `user` query parameter before Vercel Analytics sends page-view or custom events
- preserve unrelated query parameters, paths, and URL fragments
- route global analytics through a client wrapper with `beforeSend`
- align privacy documentation and browser coverage with the enforced behavior

## Root cause

Shared searches update the browser URL with `?user=<handle>` before analytics events are emitted. The global Analytics component had no `beforeSend` redaction hook, so usernames could remain in analytics event URLs even though custom event properties excluded them.

## Impact

Vercel Analytics no longer receives searched usernames in event URLs. Existing privacy-safe event properties and unrelated URL state are preserved.

## Validation

- focused sanitizer and wrapper unit TDD
- full unit suite: 131/131
- full Playwright suite: 22/22
- dependency audit, ESLint, Prettier, agent-doc and label checks
- production build and TypeScript
- UI review and code review approved with zero findings

Closes #103