### PR TITLE
fix(logging): sanitize GitHub error metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Fixed
 
+- GitHub search failure logs now exclude raw upstream messages and accept only validated numeric rate-limit metadata.
 - Vercel Analytics event URLs now remove shared-search usernames while preserving unrelated query parameters.
 - Forged Server Action requests with non-string usernames now return validation errors safely.
 - Commit results with missing or invalid dates no longer crash the result timeline.

--- a/app/actions.test.ts
+++ b/app/actions.test.ts
@@ -328,9 +328,9 @@ describe("getCommits", () => {
     expect(console.warn).toHaveBeenCalledWith({
       event: "github_commit_search_rate_limited",
       status: 403,
-      message: "API rate limit exceeded for user.",
-      rateLimitRemaining: "0",
-      rateLimitReset: "1710000000",
+      errorKind: "rate_limit",
+      rateLimitRemaining: 0,
+      rateLimitReset: 1710000000,
     });
   });
 
@@ -349,10 +349,45 @@ describe("getCommits", () => {
     expect(console.warn).toHaveBeenCalledWith({
       event: "github_commit_search_rate_limited",
       status: 429,
-      message: "Too many requests",
+      errorKind: "rate_limit",
       rateLimitRemaining: undefined,
       rateLimitReset: undefined,
     });
+  });
+
+  it("logs only allowlisted numeric rate-limit metadata", async () => {
+    const rawMessage =
+      "Request failed: https://api.github.com/search/commits?q=author%3Aoctocat with token ghp_exampleSecret123";
+    searchCommits.mockRejectedValue({
+      status: 403,
+      message: rawMessage,
+      response: {
+        headers: {
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": "1710000000 ghp_headerSecret456",
+        },
+      },
+    });
+
+    await expect(getCommits("octocat")).resolves.toEqual({
+      found: false,
+      error: "GitHub rate limit reached. Please try again in a few minutes.",
+      errorKind: "rate_limit",
+      commits: [],
+    });
+    expect(console.warn).toHaveBeenCalledWith({
+      event: "github_commit_search_rate_limited",
+      status: 403,
+      errorKind: "rate_limit",
+      rateLimitRemaining: 0,
+      rateLimitReset: undefined,
+    });
+    const serializedLogs = JSON.stringify(vi.mocked(console.warn).mock.calls);
+    expect(serializedLogs).not.toContain("octocat");
+    expect(serializedLogs).not.toContain("api.github.com");
+    expect(serializedLogs).not.toContain("q=author");
+    expect(serializedLogs).not.toContain("ghp_exampleSecret123");
+    expect(serializedLogs).not.toContain("ghp_headerSecret456");
   });
 
   it("returns a friendly timeout message when GitHub does not respond in time", async () => {
@@ -369,14 +404,16 @@ describe("getCommits", () => {
     expect(console.warn).toHaveBeenCalledWith({
       event: "github_commit_search_timeout",
       status: undefined,
-      message: "The operation was aborted",
+      errorKind: "timeout",
     });
   });
 
-  it("returns a friendly unavailable message for GitHub 5xx errors", async () => {
+  it("returns a friendly unavailable message without logging raw GitHub error details", async () => {
+    const rawMessage =
+      "Request failed: https://api.github.com/search/commits?q=author%3Aoctocat with token ghp_exampleSecret123";
     const error = {
       status: 503,
-      message: "Service Unavailable",
+      message: rawMessage,
     };
     searchCommits.mockRejectedValue(error);
 
@@ -389,8 +426,13 @@ describe("getCommits", () => {
     expect(console.error).toHaveBeenCalledWith({
       event: "github_commit_search_unavailable",
       status: 503,
-      message: "Service Unavailable",
+      errorKind: "unavailable",
     });
+    const serializedLogs = JSON.stringify(vi.mocked(console.error).mock.calls);
+    expect(serializedLogs).not.toContain("octocat");
+    expect(serializedLogs).not.toContain("api.github.com");
+    expect(serializedLogs).not.toContain("q=author");
+    expect(serializedLogs).not.toContain("ghp_exampleSecret123");
   });
 
   it("does not classify non-rate-limit GitHub 403 errors as rate limits", async () => {
@@ -410,7 +452,7 @@ describe("getCommits", () => {
     expect(console.error).toHaveBeenCalledWith({
       event: "github_commit_search_failed",
       status: 403,
-      message: "Resource not accessible by integration",
+      errorKind: "unknown",
     });
   });
 
@@ -471,7 +513,7 @@ describe("getCommits", () => {
     expect(console.error).toHaveBeenCalledWith({
       event: "github_commit_search_failed",
       status: 422,
-      message: undefined,
+      errorKind: "validation",
     });
   });
 
@@ -488,7 +530,7 @@ describe("getCommits", () => {
     expect(console.error).toHaveBeenCalledWith({
       event: "github_commit_search_failed",
       status: undefined,
-      message: "GitHub is unavailable",
+      errorKind: "unknown",
     });
   });
 });

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -25,10 +25,21 @@ function commitSearchError(error: string, errorKind: CommitErrorKind): CommitDat
 
 type GitHubErrorDetails = {
   message?: string;
-  rateLimitRemaining?: string;
-  rateLimitReset?: string;
+  rateLimitRemaining?: number;
+  rateLimitReset?: number;
   status?: unknown;
 };
+
+function parseNonNegativeInteger(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+  }
+
+  if (typeof value !== "string" || !/^\d+$/.test(value)) return undefined;
+
+  const parsedValue = Number(value);
+  return Number.isSafeInteger(parsedValue) ? parsedValue : undefined;
+}
 
 function getE2eCommitSearchResult(username: string): CommitData | null {
   if (!E2E_COMMIT_SEARCH_MOCKS_ENABLED) return null;
@@ -129,20 +140,20 @@ function getGitHubErrorDetails(error: unknown): GitHubErrorDetails {
     "headers" in error.response &&
     typeof error.response.headers === "object" &&
     error.response.headers !== null
-      ? (error.response.headers as Record<string, string | undefined>)
+      ? (error.response.headers as Record<string, unknown>)
       : undefined;
 
   return {
     message,
-    rateLimitRemaining: headers?.["x-ratelimit-remaining"],
-    rateLimitReset: headers?.["x-ratelimit-reset"],
+    rateLimitRemaining: parseNonNegativeInteger(headers?.["x-ratelimit-remaining"]),
+    rateLimitReset: parseNonNegativeInteger(headers?.["x-ratelimit-reset"]),
     status,
   };
 }
 
 function isGitHubRateLimitError(errorDetails: GitHubErrorDetails) {
   if (errorDetails.status === 429) return true;
-  if (errorDetails.rateLimitRemaining === "0") return true;
+  if (errorDetails.rateLimitRemaining === 0) return true;
 
   return (
     errorDetails.status === 403 && /rate limit|too many requests/i.test(errorDetails.message ?? "")
@@ -342,7 +353,7 @@ export async function getCommits(username: string): Promise<CommitData> {
         event: "github_commit_search_timeout",
         fields: {
           status: typeof status === "number" ? status : undefined,
-          message: errorDetails.message,
+          errorKind: "timeout",
         },
       });
       return commitSearchError("GitHub took too long to respond. Please try again.", "timeout");
@@ -353,7 +364,7 @@ export async function getCommits(username: string): Promise<CommitData> {
         event: "github_commit_search_rate_limited",
         fields: {
           status: typeof status === "number" ? status : undefined,
-          message: errorDetails.message,
+          errorKind: "rate_limit",
           rateLimitRemaining: errorDetails.rateLimitRemaining,
           rateLimitReset: errorDetails.rateLimitReset,
         },
@@ -369,7 +380,7 @@ export async function getCommits(username: string): Promise<CommitData> {
         event: "github_commit_search_unavailable",
         fields: {
           status: typeof status === "number" ? status : undefined,
-          message: errorDetails.message,
+          errorKind: "unavailable",
         },
       });
       return commitSearchError(
@@ -378,11 +389,12 @@ export async function getCommits(username: string): Promise<CommitData> {
       );
     }
 
+    const errorKind: CommitErrorKind = status === 422 ? "validation" : "unknown";
     logger.error({
       event: "github_commit_search_failed",
       fields: {
         status: typeof status === "number" ? status : undefined,
-        message: errorDetails.message,
+        errorKind,
       },
     });
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -225,12 +225,14 @@ GitHub API failures are logged with structured event names:
 Useful fields include:
 
 - `status`
-- `message`
+- `errorKind`
 - `rateLimitRemaining`
 - `rateLimitReset`
 - `itemIndex`
 
-Search usernames and tokens should not appear in logs.
+Upstream error messages are used only to classify failures and are not logged. Rate-limit metadata
+is logged only when header values are valid non-negative integers. Search usernames, request URLs,
+tokens, and raw upstream error details should not appear in logs.
 
 ## Security Headers
 


### PR DESCRIPTION
## Summary

- keep raw GitHub error messages available only for internal failure classification
- emit allowlisted `status` and `errorKind` fields instead of upstream messages
- validate rate-limit headers as non-negative safe integers before logging them
- align production logging documentation and regression coverage with the enforced privacy boundary

## Root cause

Every GitHub failure branch copied the upstream `error.message` into structured logs. Octokit and network errors can include request URLs, search queries, usernames, or token-like data, contradicting the repository's logging policy.

## Impact

Rate-limit, timeout, unavailable, validation, and unknown responses are unchanged for users. Operators retain safe event names, categories, status values, and numeric rate-limit metadata without receiving raw upstream error details.

## Validation

- focused red/green Server Action unit tests with URL, query, username, token-shaped, and malformed-header values
- full unit suite: 132/132
- full Playwright suite: 22/22
- dependency audit, ESLint, Prettier, agent-doc and label checks
- production build and TypeScript
- UI review and code review approved with zero findings

Closes #104