### PR TITLE
fix(a11y): improve action contrast and result focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Fixed
 
+- Primary green actions now meet WCAG AA text contrast, and successful searches move focus to the result heading for a clear assistive-technology transition.
 - GitHub search failure logs now exclude raw upstream messages and accept only validated numeric rate-limit metadata.
 - Vercel Analytics event URLs now remove shared-search usernames while preserving unrelated query parameters.
 - Forged Server Action requests with non-string usernames now return validation errors safely.

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,8 +8,8 @@
   --github-blue: #0969da;
   --github-gray-light: #f6f8fa;
   --github-border: #d0d7de;
-  --github-green: #2da44e;
-  --github-green-hover: #2c974b;
+  --github-green: #1f883d;
+  --github-green-hover: #1a7f37;
   --github-gray-text: #57606a;
   --github-gray-dark: #24292f;
 }

--- a/app/home/SearchResults.tsx
+++ b/app/home/SearchResults.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { GoCopy } from "react-icons/go";
 import FirstCommitDisplay from "@/components/FirstCommitDisplay";
 import { githubRepositoryUrl } from "../githubUrls";
@@ -16,7 +17,13 @@ export default function SearchResults({
   shareStatus,
   onCopy,
 }: SearchResultsProps) {
+  const resultHeadingRef = useRef<HTMLHeadingElement>(null);
   const firstCommit = commits[0];
+
+  useEffect(() => {
+    if (firstCommit) resultHeadingRef.current?.focus();
+  }, [firstCommit, lastSearchedUsername]);
+
   if (!firstCommit) return null;
 
   const uniqueRepositoryCount = new Set(commits.map((commit) => commit.repository.full_name)).size;
@@ -24,7 +31,11 @@ export default function SearchResults({
   return (
     <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 w-full flex flex-col items-center pb-12 pt-8">
       <div className="mb-6 w-full max-w-2xl text-left">
-        <h1 className="text-2xl font-bold text-[var(--github-gray-dark)]">
+        <h1
+          ref={resultHeadingRef}
+          tabIndex={-1}
+          className="rounded-sm text-2xl font-bold text-[var(--github-gray-dark)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
+        >
           First public commit found
         </h1>
         <p className="mt-2 text-sm text-[var(--github-gray-dark)]">

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -89,6 +89,9 @@ describe("Home", () => {
     expect(
       await screen.findByRole("heading", { name: /first public commit found/i }),
     ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /first public commit found/i })).toHaveFocus();
+    });
     expect(screen.getByText(/github search may miss older commits/i)).toBeInTheDocument();
     expect(
       screen.getByText(/earliest indexed public commit for @octo appears in/i),

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIResponse, type Page } from "@playwright/test";
+import { expect, test, type APIResponse, type Locator, type Page } from "@playwright/test";
 
 const isDeployedTarget = Boolean(process.env.PLAYWRIGHT_BASE_URL);
 
@@ -44,6 +44,30 @@ function captureReactRenderErrors(page: Page) {
   page.on("pageerror", (error) => renderErrors.push(error.message));
 
   return renderErrors;
+}
+
+async function getTextContrastRatio(locator: Locator) {
+  return locator.evaluate((element) => {
+    const parseRgb = (color: string) =>
+      color
+        .match(/[\d.]+/g)!
+        .slice(0, 3)
+        .map(Number);
+    const relativeLuminance = (color: string) => {
+      const channels = parseRgb(color).map((channel) => {
+        const normalized = channel / 255;
+        return normalized <= 0.04045 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+      });
+      return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+    };
+    const styles = getComputedStyle(element);
+    const foreground = relativeLuminance(styles.color);
+    const background = relativeLuminance(styles.backgroundColor);
+    const lighter = Math.max(foreground, background);
+    const darker = Math.min(foreground, background);
+
+    return (lighter + 0.05) / (darker + 0.05);
+  });
 }
 
 test("home page search field is keyboard-ready and not treated as a credential field", async ({
@@ -346,6 +370,28 @@ test.describe("local mocked commit search states", () => {
     ).toBeVisible();
     await expect(page).toHaveURL(/\?user=e2e-result$/);
     expect(renderErrors).toEqual([]);
+  });
+
+  test("successful search focuses its heading and action colors meet AA contrast", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("searchbox", { name: "GitHub username" }).fill("e2e-result");
+    const searchButton = page.getByRole("button", { name: "Search", exact: true });
+    await expect(searchButton).toBeEnabled();
+    expect(await getTextContrastRatio(searchButton)).toBeGreaterThanOrEqual(4.5);
+
+    await searchButton.hover();
+    await expect.poll(() => getTextContrastRatio(searchButton)).toBeGreaterThanOrEqual(4.5);
+    await searchButton.click();
+
+    const resultHeading = page.getByRole("heading", { name: "First public commit found" });
+    await expect(resultHeading).toBeFocused();
+
+    await page.getByRole("button", { name: "Search another user" }).click();
+    await expect(page.getByRole("searchbox", { name: "GitHub username" })).toBeFocused();
   });
 
   test("search shortcuts stay disabled while a request is pending", async ({ page }) => {


### PR DESCRIPTION
## Summary

- replace the shared green action palette with WCAG AA-compliant normal and hover colors
- move programmatic focus to the visible successful-result heading without adding it to sequential tab order
- preserve focus restoration when starting another search
- add computed-style contrast and end-to-end focus regressions

## Root cause

White text on the existing green action colors measured only 3.215:1 normally and 3.73:1 on hover. Successful results also replaced the focused search form without moving focus or announcing the new result context.

## Impact

Enabled primary actions now meet the WCAG AA 4.5:1 minimum for normal-size text. Keyboard and screen-reader users receive a clear, visible successful-result transition, and can return to the search input through the existing new-search action.

## Validation

- measured normal contrast: 4.519:1
- measured hover contrast: 5.079:1
- focused red/green unit and Playwright TDD
- full unit suite: 132/132
- full Playwright suite: 23/23
- dependency audit, ESLint, Prettier, agent-doc and label checks
- production build and TypeScript
- UI review and code review approved with zero findings

Closes #110