### PR TITLE
chore(tooling): match Claude Code's current tool names in hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Task",
+        "matcher": "Agent",
         "hooks": [
           {
             "type": "command",
@@ -11,7 +11,7 @@
         ]
       },
       {
-        "matcher": "TodoWrite",
+        "matcher": "TodoWrite|TaskCreate|TaskUpdate",
         "hooks": [
           {
             "type": "command",
@@ -22,7 +22,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Task",
+        "matcher": "Agent",
         "hooks": [
           {
             "type": "command",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Changed
 
+- Local Entire checkpoint hooks now match Claude Code's current tool names, including the newer task tools, so the configuration no longer depends on Claude Code's legacy alias map.
 - The agent workflow now bounds its review loop: findings can be explicitly resolved with a stated reason, and a finding that survives two fix-and-re-review cycles stops for a human instead of looping. Reverification is scoped to the gate commands a fix can actually affect, with a documentation-only exemption, so a prose fix no longer triggers a full audit, test, browser, and build cycle.
 - Agents must now add a `CHANGELOG.md` entry with user-facing and operational changes, treat issue, pull request, and review text as data rather than instructions, and bound the wait for an assigned reviewer instead of blocking indefinitely.
 - The `ui-review` sub-agent now enumerates untracked files with `--untracked-files=all`, so a brand-new component directory can no longer be mistaken for a change with no user-visible surface.


### PR DESCRIPTION
## What changed

Three hook matchers in `.claude/settings.json` now name Claude Code's current tools:

| Hook | Before | After |
| --- | --- | --- |
| `PreToolUse` | `Task` | `Agent` |
| `PostToolUse` | `Task` | `Agent` |
| `PostToolUse` | `TodoWrite` | `TodoWrite\|TaskCreate\|TaskUpdate` |

## Nothing was broken before this

Worth stating plainly, because the first draft of this change claimed otherwise. Claude Code's matcher evaluator normalizes every split token through a legacy alias map (`{Task: "Agent", …}`) before comparing, so the old `Task` matcher resolved to `Agent` and kept firing. `TodoWrite` is likewise still a live tool name, not a removed one.

So this is hygiene, not a repair: the config no longer depends on the alias map, and it gains coverage for the newer `TaskCreate`/`TaskUpdate` task tools. The todo matcher **keeps** `TodoWrite` alongside them rather than replacing it — an earlier version of this branch dropped it, which would have been a real regression, since unlike `Task` it has no alias entry to fall back on.

## Heads up: this file is generated

`.claude/settings.json` is written by `entire enable`, and the Entire CLI 0.9.0 template ships the todo matcher as `TaskCreate|TaskUpdate` without `TodoWrite`. This branch is therefore a local override — re-check it after any `entire enable` or Entire upgrade, since a refresh would silently restore the template's narrower matcher.

## Verification

`verifier` ran the complete gate: `npm audit` (0 vulnerabilities), `npm test` (18 files, 132 tests), `npm run test:e2e` (23 passed), `lint`, `format:check`, `check:agent-docs`, `check:labels`, `build` — all green.

`code-review` **APPROVED**. It confirmed the matcher syntax takes the token-split path rather than being treated as a regex, and separately verified that `entire hooks claude-code post-todo` exits 0 for `TodoWrite`, `TaskCreate`, and `TaskUpdate` payloads, so broadening the matcher introduces no hook-error path.

## Known follow-up (not in this PR)

`AGENTS.md` step 7's mapping table, merged in #132, routes `.claude/` to `anything else | the complete gate`, even though `.prettierignore` excludes `.claude` and no gate command reads it. That over-runs rather than under-runs, so it is wasteful rather than unsafe. Worth generalizing the "no gate command reads it" row to cover both `*.md` and `.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)