### PR TITLE
chore(agents): drop the Copilot instruction file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,9 +1,0 @@
-# GitHub Copilot
-
-Project instructions for this repository live in one canonical file: [AGENTS.md](../AGENTS.md).
-
-Read [AGENTS.md](../AGENTS.md) for commands, layout, gotchas, and conventions.
-
-Do not add project instructions to this file. Anything worth remembering belongs in
-[AGENTS.md](../AGENTS.md) instead. CI runs `npm run check:agent-docs`, which fails if this file
-drifts from the pointer template.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Instructions
 
-Canonical instructions for coding agents working in this repository. `CLAUDE.md`, `GEMINI.md`, and
-`.github/copilot-instructions.md` are pointers to this file and must stay pointers. Add project
-context here, never in the pointer files. CI enforces this with `npm run check:agent-docs`.
+Canonical instructions for coding agents working in this repository. `CLAUDE.md` and `GEMINI.md` are
+pointers to this file and must stay pointers. Add project context here, never in the pointer files.
+CI enforces this with `npm run check:agent-docs`.
 
 ## Project
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 - Removed the superseded specification and roadmap documents, along with their README links.
 - Upgraded the project from Node 22 to Node 24, the current Active LTS and Vercel's default runtime. `.nvmrc`, `package.json` engines, and the docs now all name 24. Node 26 is deliberately not used: Vercel offers only 20.x, 22.x, and 24.x, so pinning 26 would not deploy.
 
+### Removed
+
+- Copilot-specific instruction file. `.github/copilot-instructions.md` is deleted and deregistered from `npm run check:agent-docs`, which now keeps only `CLAUDE.md` and `GEMINI.md` as pointers to `AGENTS.md`. Copilot CLI, the Copilot cloud agent, Copilot code review, and Copilot Chat in VS Code read `AGENTS.md` natively, so those surfaces keep the same instructions; Copilot Chat on GitHub.com and in Visual Studio, JetBrains, Eclipse, and Xcode do not read `AGENTS.md` and no longer receive repository instructions. The check now also fails if the file reappears, since it would outrank `AGENTS.md`. The Copilot CLI hook file `.github/hooks/entire.json` is unaffected and stays.
+
 ## 0.3.0 - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The app is a Next.js App Router project. The browser collects a GitHub username,
 - Use the [manual QA checklist](docs/manual-qa.md) for release and Open Graph preview validation.
 - Use the [release guide](docs/release.md) to cut tags and GitHub releases.
 - Use the [contributing guide](CONTRIBUTING.md) for branch, PR, review, and validation workflow.
-- Use [AGENTS.md](AGENTS.md) for coding agent instructions. It is the single canonical file; `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` are pointers to it, enforced by `npm run check:agent-docs`.
+- Use [AGENTS.md](AGENTS.md) for coding agent instructions. It is the single canonical file; `CLAUDE.md` and `GEMINI.md` are pointers to it, enforced by `npm run check:agent-docs`.
 - Use the [label guide](docs/labels.md) for issue and pull request labels.
 - Use the [changelog](CHANGELOG.md) to track user-facing changes and release notes.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,10 +65,10 @@ npm run build
 ```
 
 `npm run check:agent-docs` keeps [AGENTS.md](../AGENTS.md) the single source of agent instructions.
-`CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` must stay byte-for-byte pointers to
-it, so notes captured by a coding agent (for example Claude Code's `#` shortcut) do not quietly
-accumulate in a tool-specific file. Move the content into `AGENTS.md`, then run
-`npm run check:agent-docs -- --fix` to restore the pointers.
+`CLAUDE.md` and `GEMINI.md` must stay byte-for-byte pointers to it, so notes captured by a coding
+agent (for example Claude Code's `#` shortcut) do not quietly accumulate in a tool-specific file.
+Move the content into `AGENTS.md`, then run `npm run check:agent-docs -- --fix` to restore the
+pointers.
 
 `npm run check:labels` validates `.github/labels.yml` offline, without a token or network access. See
 [labels](labels.md) for syncing labels to GitHub.

--- a/scripts/check-agent-docs.mjs
+++ b/scripts/check-agent-docs.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // Keeps AGENTS.md the single source of agent instructions.
 //
-// CLAUDE.md, GEMINI.md, and .github/copilot-instructions.md must stay byte-for-byte pointers to
-// AGENTS.md. Claude Code's `#` shortcut appends learnings to CLAUDE.md, which is exactly the drift
-// this guards against: the check fails, and the content moves to AGENTS.md instead.
+// CLAUDE.md and GEMINI.md must stay byte-for-byte pointers to AGENTS.md. Claude Code's `#` shortcut
+// appends learnings to CLAUDE.md, which is exactly the drift this guards against: the check fails,
+// and the content moves to AGENTS.md instead.
 //
 // Usage:
 //   node scripts/check-agent-docs.mjs          verify (exit 1 on drift)
@@ -18,6 +18,9 @@ const CANONICAL_DOC = "AGENTS.md";
 const MIN_CANONICAL_LINES = 20;
 const WRAP_COLUMNS = 100;
 
+// `link` is the path to AGENTS.md relative to the pointer file's own directory. Both current
+// pointers sit at the repo root, so both use "AGENTS.md"; a pointer added under a subdirectory
+// needs its own relative path, for example "../AGENTS.md".
 const POINTER_DOCS = [
   {
     file: "CLAUDE.md",
@@ -31,13 +34,13 @@ const POINTER_DOCS = [
     link: "AGENTS.md",
     note: "Anything worth remembering belongs in",
   },
-  {
-    file: ".github/copilot-instructions.md",
-    title: "GitHub Copilot",
-    link: "../AGENTS.md",
-    note: "Anything worth remembering belongs in",
-  },
 ];
+
+// Files that must not exist. GitHub ranks .github/copilot-instructions.md above AGENTS.md, so a
+// regenerated one would quietly become the highest-precedence instruction source and AGENTS.md
+// would no longer be canonical. Copilot is not used here, and its CLI, cloud agent, and code
+// review read AGENTS.md natively.
+const FORBIDDEN_DOCS = [".github/copilot-instructions.md"];
 
 function wrap(text, width) {
   const lines = [];
@@ -110,12 +113,23 @@ async function main() {
     );
   }
 
+  for (const file of FORBIDDEN_DOCS) {
+    if ((await readIfPresent(join(repoRoot, file))) === null) continue;
+    problems.push(
+      `${file} exists. It outranks ${CANONICAL_DOC}, so it would quietly become the highest-` +
+        `precedence instruction source. Move its content into ${CANONICAL_DOC} and delete it.`,
+    );
+  }
+
+  let pointerDrifted = false;
+
   for (const doc of POINTER_DOCS) {
     const path = join(repoRoot, doc.file);
     const expected = expectedContent(doc);
     const actual = await readIfPresent(path);
 
     if (actual === expected) continue;
+    pointerDrifted = true;
 
     if (fix) {
       await writeFile(path, expected, "utf8");
@@ -148,10 +162,14 @@ async function main() {
   if (problems.length > 0) {
     console.error("Agent instruction files are out of sync:\n");
     console.error(`${problems.join("\n\n")}\n`);
-    console.error(
-      `Move any real instructions into ${CANONICAL_DOC}, then run ` +
-        "`npm run check:agent-docs -- --fix` to restore the pointer files.",
-    );
+    // Only suggest --fix when it can actually help. It rewrites drifted pointers; it never
+    // deletes a forbidden file, so offering it there would send the reader in a circle.
+    if (pointerDrifted) {
+      console.error(
+        `Move any real instructions into ${CANONICAL_DOC}, then run ` +
+          "`npm run check:agent-docs -- --fix` to restore the pointer files.",
+      );
+    }
     process.exit(1);
   }
 


### PR DESCRIPTION
## What changed

The project no longer uses Copilot for code review, and `.github/copilot-instructions.md` was the last instruction file carrying that assumption.

- Deletes `.github/copilot-instructions.md`
- Deregisters it from `scripts/check-agent-docs.mjs`, which now keeps only `CLAUDE.md` and `GEMINI.md` as pointers
- Updates the prose in `AGENTS.md`, `README.md`, and `docs/development.md` that described a trio of pointer files

## The guard

Deleting the file is not enough on its own. GitHub ranks `.github/copilot-instructions.md` **above** `AGENTS.md` in precedence, and it can be regenerated in one click. Without a guard, a future PR could silently reinstate a higher-precedence instruction source while `npm run check:agent-docs` stayed green and `AGENTS.md` quietly stopped being canonical.

So `check-agent-docs` now fails if the file reappears, naming the precedence problem and the remedy. Related fix: the closing "run `--fix`" hint is now gated on actual pointer drift, since `--fix` deliberately will not delete a forbidden file and following that hint previously looped.

## What this costs

Not nothing, and worth stating plainly:

| Surface | Reads `AGENTS.md`? |
| --- | --- |
| Copilot CLI, cloud agent, code review, Chat in VS Code | Yes — keeps these instructions |
| Chat on github.com, Visual Studio, JetBrains, Eclipse, Xcode | **No** — loses repository instructions |

Those second-row surfaces are unused here, so the tradeoff is accepted.

## Deliberately retained

- **`CHANGELOG.md` `0.2.0` entry** names the deleted file. It describes what shipped then; rewriting released history would falsify the record.
- **`.github/hooks/entire.json`** invokes `entire hooks copilot-cli …`. That is Copilot CLI *hook wiring* for the Entire CLI, not instruction support. Deleting it would break Entire's hooks, not remove Copilot review.

## Verification

`verifier` ran the complete gate (8 commands, all green), then the `scripts/` mapping row after a follow-up edit (7 commands, all green). It separately proved the removal did not weaken `check-agent-docs` into a no-op — it still fails on pointer drift, on a missing pointer, and on a stubbed `AGENTS.md`, and `--fix` still restores both remaining pointers byte-identically.

The guard was exercised across clean / forbidden-only / drift-only / both states, from a different working directory, with an empty forbidden file, and against near-miss decoy paths (`.github/copilot-instructions.md.disabled`, `.github/copilot-instructions/notes.md`, `docs/copilot-instructions.md`) — no false positives.

`ui-review`: no user-visible surface. `code-review`: **APPROVED**.

## Known gap

The guard's failure path has no automated regression. Vitest would pick up `scripts/*.test.mjs` today, but the script resolves `repoRoot` from its own location and calls `process.exit` at import, so covering it needs a fixture-copy helper rather than a single test file. Deferred to its own change; the path was verified by hand as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)