### PR TITLE
fix(actions): handle incomplete GitHub search results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,9 @@ drift. Run the individual commands above when a scoped rerun is enough, per step
 
 - **E2E mocks.** `E2E_COMMIT_SEARCH_MOCKS=1` makes `app/actions.ts` return fixtures for the reserved
   usernames `e2e-result`, `e2e-slow-result`, `e2e-reject-once-*`, `e2e-malformed-dates`,
-  `e2e-empty`, `e2e-rate-limit`, and `e2e-unavailable`. Playwright sets this automatically and runs
-  the app on port **3100**, not 3000. Add new fixture cases in `app/actions.ts` when adding browser
-  coverage for a new state.
+  `e2e-incomplete`, `e2e-incomplete-empty`, `e2e-empty`, `e2e-rate-limit`, and `e2e-unavailable`.
+  Playwright sets this automatically and runs the app on port **3100**, not 3000. Add new fixture
+  cases in `app/actions.ts` when adding browser coverage for a new state.
 - **Prettier ignores `*.md`.** Prose is formatted by hand. Do not run the formatter over docs, and do
   not reflow markdown as part of an unrelated change.
 - **The commit cache is per-process.** It is a plain `Map`, so it resets on every serverless cold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Fixed
 
+- A commit search that GitHub abandoned before scanning every commit is now labelled a partial result rather than "First public commit found", explains that an earlier commit may be missing, and is never cached, so searching again can reach the full history. An unfinished search that returned nothing is reported as unfinished instead of as an absence of commits, offers a retry, and no longer suggests checking a different profile. Copied result text carries the same caveat.
 - Primary green actions now meet WCAG AA text contrast, and successful searches move focus to the result heading for a clear assistive-technology transition.
 - GitHub search failure logs now exclude raw upstream messages and accept only validated numeric rate-limit metadata.
 - Vercel Analytics event URLs now remove shared-search usernames while preserving unrelated query parameters.

--- a/app/actions.test.ts
+++ b/app/actions.test.ts
@@ -307,6 +307,83 @@ describe("getCommits", () => {
     });
   });
 
+  it("marks partial results when GitHub reports an incomplete search", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [commitItem],
+        incomplete_results: true,
+      },
+    });
+
+    const result = await getCommits("octo");
+
+    expect(result.found).toBe(true);
+    expect(result.incomplete).toBe(true);
+    expect(result.commits).toHaveLength(1);
+    expect(console.warn).toHaveBeenCalledWith({
+      event: "github_commit_search_incomplete",
+      itemCount: 1,
+    });
+  });
+
+  it("does not cache an incomplete search, so a retry can reach a complete result", async () => {
+    searchCommits.mockResolvedValueOnce({
+      data: {
+        items: [commitItem],
+        incomplete_results: true,
+      },
+    });
+    searchCommits.mockResolvedValueOnce({
+      data: {
+        items: [commitItem],
+        incomplete_results: false,
+      },
+    });
+
+    const incompleteResult = await getCommits("octo");
+    const completeResult = await getCommits("octo");
+
+    expect(searchCommits).toHaveBeenCalledTimes(2);
+    expect(incompleteResult.incomplete).toBe(true);
+    expect(completeResult.incomplete).toBeUndefined();
+  });
+
+  it("marks an incomplete empty search as partial and does not cache it", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [],
+        incomplete_results: true,
+      },
+    });
+
+    const result = await getCommits("octo");
+    await getCommits("octo");
+
+    expect(result).toEqual({
+      found: false,
+      error: "GitHub could not finish this search, so no commits were returned yet.",
+      errorKind: "empty",
+      incomplete: true,
+      commits: [],
+    });
+    expect(searchCommits).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches and does not mark complete searches as partial", async () => {
+    searchCommits.mockResolvedValue({
+      data: {
+        items: [commitItem],
+        incomplete_results: false,
+      },
+    });
+
+    const result = await getCommits("octo");
+    await getCommits("octo");
+
+    expect(result.incomplete).toBeUndefined();
+    expect(searchCommits).toHaveBeenCalledTimes(1);
+  });
+
   it("returns a helpful rate limit message and logs a structured warning for GitHub rate-limit 403 errors", async () => {
     searchCommits.mockRejectedValue({
       status: 403,

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -18,9 +18,15 @@ const E2E_REJECT_ONCE_USERNAME_PREFIX = "e2e-reject-once-";
 const e2eRejectedUsernames = new Set<string>();
 const EMPTY_COMMIT_SEARCH_MESSAGE =
   "No public commits found for this user (or indexing is delayed).";
+const INCOMPLETE_COMMIT_SEARCH_MESSAGE =
+  "GitHub could not finish this search, so no commits were returned yet.";
 
-function commitSearchError(error: string, errorKind: CommitErrorKind): CommitData {
-  return { found: false, error, errorKind, commits: [] };
+function commitSearchError(
+  error: string,
+  errorKind: CommitErrorKind,
+  incomplete = false,
+): CommitData {
+  return { found: false, error, errorKind, ...(incomplete ? { incomplete } : {}), commits: [] };
 }
 
 type GitHubErrorDetails = {
@@ -86,6 +92,14 @@ function getE2eCommitSearchResult(username: string): CommitData | null {
     };
   }
 
+  if (username === "e2e-incomplete") {
+    return {
+      found: true,
+      incomplete: true,
+      commits: [mockCommit],
+    };
+  }
+
   if (username === "e2e-malformed-dates") {
     return {
       found: true,
@@ -110,6 +124,8 @@ function getE2eCommitSearchResult(username: string): CommitData | null {
   switch (username) {
     case "e2e-empty":
       return commitSearchError(EMPTY_COMMIT_SEARCH_MESSAGE, "empty");
+    case "e2e-incomplete-empty":
+      return commitSearchError(INCOMPLETE_COMMIT_SEARCH_MESSAGE, "empty", true);
     case "e2e-rate-limit":
       return commitSearchError(
         "GitHub rate limit reached. Please try again in a few minutes.",
@@ -312,9 +328,27 @@ export async function getCommits(username: string): Promise<CommitData> {
     );
 
     const items = response.data.items;
+    // GitHub abandons a commit search that runs too long and still returns 200 with
+    // whatever it had indexed so far. Treating that as authoritative would claim a
+    // "first" commit that may not be the earliest one, so it stays flagged and
+    // uncached; setCachedCommitSearch drops incomplete results.
+    const isIncompleteSearch = response.data.incomplete_results === true;
+
+    if (isIncompleteSearch) {
+      logger.warn({
+        event: "github_commit_search_incomplete",
+        fields: {
+          itemCount: items?.length ?? 0,
+        },
+      });
+    }
 
     if (!items || items.length === 0) {
-      const emptyResult = commitSearchError(EMPTY_COMMIT_SEARCH_MESSAGE, "empty");
+      const emptyResult = commitSearchError(
+        isIncompleteSearch ? INCOMPLETE_COMMIT_SEARCH_MESSAGE : EMPTY_COMMIT_SEARCH_MESSAGE,
+        "empty",
+        isIncompleteSearch,
+      );
       setCachedCommitSearch(cacheKey, emptyResult);
       return emptyResult;
     }
@@ -333,13 +367,18 @@ export async function getCommits(username: string): Promise<CommitData> {
     });
 
     if (commits.length === 0) {
-      const emptyResult = commitSearchError(EMPTY_COMMIT_SEARCH_MESSAGE, "empty");
+      const emptyResult = commitSearchError(
+        isIncompleteSearch ? INCOMPLETE_COMMIT_SEARCH_MESSAGE : EMPTY_COMMIT_SEARCH_MESSAGE,
+        "empty",
+        isIncompleteSearch,
+      );
       setCachedCommitSearch(cacheKey, emptyResult);
       return emptyResult;
     }
 
     const result: CommitData = {
       found: true,
+      ...(isIncompleteSearch ? { incomplete: true } : {}),
       commits,
     };
     setCachedCommitSearch(cacheKey, result);

--- a/app/commitSearchCache.test.ts
+++ b/app/commitSearchCache.test.ts
@@ -48,6 +48,19 @@ describe("commit search cache", () => {
     expect(getCachedCommitSearch("octo", 1_200)).toEqual(commitSearchResult);
   });
 
+  it("never stores an incomplete result", () => {
+    setCachedCommitSearch("octo", { ...commitSearchResult, incomplete: true }, 1_000);
+
+    expect(getCachedCommitSearch("octo", 1_100)).toBeNull();
+  });
+
+  it("does not let an incomplete result evict a cached complete result", () => {
+    setCachedCommitSearch("octo", commitSearchResult, 1_000);
+    setCachedCommitSearch("octo", { ...commitSearchResult, incomplete: true }, 1_100);
+
+    expect(getCachedCommitSearch("octo", 1_200)).toEqual(commitSearchResult);
+  });
+
   it("caps the number of cached entries", () => {
     for (let index = 0; index < 101; index += 1) {
       setCachedCommitSearch(`octo-${index}`, commitSearchResult, 1_000);

--- a/app/commitSearchCache.ts
+++ b/app/commitSearchCache.ts
@@ -55,6 +55,9 @@ export function getCachedCommitSearch(cacheKey: string, now = Date.now()) {
 
 export function setCachedCommitSearch(cacheKey: string, result: CommitData, now = Date.now()) {
   if (!result.found && result.errorKind !== "empty") return;
+  // A partial result would otherwise be served as definitive for the whole TTL,
+  // and would evict a complete result already cached for this user.
+  if (result.incomplete) return;
 
   pruneExpiredEntries(now);
   commitSearchCache.set(cacheKey, {

--- a/app/commitTypes.ts
+++ b/app/commitTypes.ts
@@ -22,5 +22,11 @@ export type CommitData = {
   found: boolean;
   error?: string;
   errorKind?: CommitErrorKind;
+  /**
+   * GitHub reported `incomplete_results`, meaning the search timed out before
+   * scanning every commit. An earlier commit may exist that this result misses,
+   * so partial results are surfaced to the visitor and never cached.
+   */
+  incomplete?: boolean;
   commits: CommitInfo[];
 };

--- a/app/home/SearchErrorState.test.tsx
+++ b/app/home/SearchErrorState.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { CommitData } from "../commitTypes";
+import SearchErrorState from "./SearchErrorState";
+
+function renderSearchErrorState(result: CommitData) {
+  render(
+    <SearchErrorState
+      result={result}
+      exampleUsernames={["octocat"]}
+      isPending={false}
+      lastSearchedUsername="octo"
+      onRetry={() => {}}
+      onReset={() => {}}
+      onExampleSearch={() => {}}
+    />,
+  );
+}
+
+describe("SearchErrorState", () => {
+  it("suggests other profiles when a finished search found nothing", () => {
+    renderSearchErrorState({ found: false, errorKind: "empty", commits: [] });
+
+    expect(screen.getByRole("heading", { name: "No public commits found." })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Check a known public profile" })).toBeVisible();
+  });
+
+  it("does not suggest other profiles when the search never finished", () => {
+    renderSearchErrorState({ found: false, errorKind: "empty", incomplete: true, commits: [] });
+
+    expect(
+      screen.getByRole("heading", { name: "GitHub could not finish this search." }),
+    ).toBeInTheDocument();
+    // Suggesting a different username implies this one was searched and came up empty.
+    expect(
+      screen.queryByRole("heading", { name: "Check a known public profile" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeVisible();
+  });
+});

--- a/app/home/SearchErrorState.tsx
+++ b/app/home/SearchErrorState.tsx
@@ -28,6 +28,9 @@ export default function SearchErrorState({
   const isEmptyResult = isEmptyCommitSearchResult(result);
   const canRetry = canRetryCommitSearch(result);
   const resultMessage = getResultMessage(result);
+  // An unfinished search shares the "empty" kind but proves nothing about this username,
+  // so pointing the visitor at other profiles would imply a conclusion GitHub never reached.
+  const suggestAlternativeProfiles = isEmptyResult && !result.incomplete;
 
   return (
     <div
@@ -39,7 +42,7 @@ export default function SearchErrorState({
         {resultMessage.title}
       </h2>
       <p className="mt-2 text-sm text-[var(--github-gray-text)]">{resultMessage.description}</p>
-      {isEmptyResult ? (
+      {suggestAlternativeProfiles ? (
         <div className="mt-4 rounded-md border border-[var(--github-border)] bg-white p-3">
           <h3 className="text-sm font-semibold text-[var(--github-gray-dark)]">
             Check a known public profile

--- a/app/home/SearchResults.test.tsx
+++ b/app/home/SearchResults.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { CommitInfo } from "../commitTypes";
+import SearchResults from "./SearchResults";
+
+const commits: CommitInfo[] = [
+  {
+    message: "Initial commit\n\nAdd the first files",
+    date: "2024-01-01T00:00:00Z",
+    html_url: "https://github.com/octo/repo/commit/abcdef123456",
+    sha: "abcdef123456",
+    repository: {
+      name: "repo",
+      owner: "octo",
+      full_name: "octo/repo",
+    },
+    author: {
+      login: "octo",
+      avatar_url: "https://github.com/octo.png",
+      html_url: "https://github.com/octo",
+    },
+  },
+];
+
+function renderSearchResults(overrides: Partial<Parameters<typeof SearchResults>[0]> = {}) {
+  render(
+    <SearchResults
+      commits={commits}
+      lastSearchedUsername="octo"
+      shareStatus=""
+      isIncomplete={false}
+      onCopy={() => {}}
+      {...overrides}
+    />,
+  );
+}
+
+describe("SearchResults", () => {
+  it("presents a complete result as the first public commit", () => {
+    renderSearchResults();
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "First public commit found",
+    );
+  });
+
+  it("does not claim a partial result is the first commit", () => {
+    renderSearchResults({ isIncomplete: true });
+
+    expect(screen.getByRole("heading", { level: 1 })).not.toHaveTextContent(
+      "First public commit found",
+    );
+    expect(
+      screen.getByRole("region", { name: "GitHub returned a partial result" }),
+    ).toHaveTextContent(/earlier commit may be missing/i);
+  });
+
+  it("describes the heading with the partial-result caveat, so taking focus announces it", () => {
+    renderSearchResults({ isIncomplete: true });
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    const descriptionId = heading.getAttribute("aria-describedby");
+
+    expect(descriptionId).toBeTruthy();
+    expect(document.getElementById(descriptionId!)).toHaveTextContent(
+      /earlier commit may be missing/i,
+    );
+  });
+
+  it("leaves the heading undescribed for a complete result", () => {
+    renderSearchResults();
+
+    expect(screen.getByRole("heading", { level: 1 })).not.toHaveAttribute("aria-describedby");
+  });
+});

--- a/app/home/SearchResults.tsx
+++ b/app/home/SearchResults.tsx
@@ -4,10 +4,14 @@ import FirstCommitDisplay from "@/components/FirstCommitDisplay";
 import { githubRepositoryUrl } from "../githubUrls";
 import type { CommitInfo } from "../commitTypes";
 
+const PARTIAL_RESULT_HEADING_ID = "partial-result-heading";
+const PARTIAL_RESULT_DESCRIPTION_ID = "partial-result-description";
+
 type SearchResultsProps = {
   commits: CommitInfo[];
   lastSearchedUsername: string;
   shareStatus: string;
+  isIncomplete: boolean;
   onCopy: () => void;
 };
 
@@ -15,6 +19,7 @@ export default function SearchResults({
   commits,
   lastSearchedUsername,
   shareStatus,
+  isIncomplete,
   onCopy,
 }: SearchResultsProps) {
   const resultHeadingRef = useRef<HTMLHeadingElement>(null);
@@ -34,11 +39,14 @@ export default function SearchResults({
         <h1
           ref={resultHeadingRef}
           tabIndex={-1}
+          aria-describedby={isIncomplete ? PARTIAL_RESULT_DESCRIPTION_ID : undefined}
           className="rounded-sm text-2xl font-bold text-[var(--github-gray-dark)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
         >
-          First public commit found
+          {isIncomplete ? "Earliest public commit found so far" : "First public commit found"}
         </h1>
-        <p className="mt-2 text-sm text-[var(--github-gray-dark)]">
+        {/* A GitHub handle is an unbreakable 40-character token, which overflows the panel at
+            a 320px viewport -- the same width 200% zoom produces on a 640px window. */}
+        <p className="mt-2 text-sm break-words text-[var(--github-gray-dark)]">
           Earliest indexed public commit for @{lastSearchedUsername} appears in{" "}
           <a
             href={githubRepositoryUrl(firstCommit.repository.full_name)}
@@ -50,10 +58,31 @@ export default function SearchResults({
             ? `, with nearby early commits across ${uniqueRepositoryCount} repositories.`
             : "."}
         </p>
-        <p className="mt-2 text-sm text-[var(--github-gray-text)]">
-          GitHub search may miss older commits when indexing is incomplete, delayed, or author
-          metadata changed.
-        </p>
+        {isIncomplete ? (
+          // The caveat is announced through the heading's description rather than a live
+          // region: the block mounts with its content already inside it, which screen
+          // readers often skip, while the heading reliably takes focus when results arrive.
+          <section
+            aria-labelledby={PARTIAL_RESULT_HEADING_ID}
+            className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-5 text-amber-900 shadow-sm"
+          >
+            <h2 id={PARTIAL_RESULT_HEADING_ID} className="text-base font-semibold">
+              GitHub returned a partial result
+            </h2>
+            {/* States the fact rather than instructing a retry: this view offers no search
+                control, so an instruction would send the visitor to the header's "Search
+                another user", which clears the very handle they were told to reuse. */}
+            <p id={PARTIAL_RESULT_DESCRIPTION_ID} className="mt-2 text-sm break-words">
+              The search timed out before scanning every commit, so an earlier commit may be
+              missing. A repeated search for @{lastSearchedUsername} often reaches the full history.
+            </p>
+          </section>
+        ) : (
+          <p className="mt-2 text-sm text-[var(--github-gray-text)]">
+            GitHub search may miss older commits when indexing is incomplete, delayed, or author
+            metadata changed.
+          </p>
+        )}
         <div className="mt-4 flex flex-wrap items-center gap-2">
           <button
             type="button"

--- a/app/home/resultMessages.test.ts
+++ b/app/home/resultMessages.test.ts
@@ -21,6 +21,14 @@ describe("getResultMessage", () => {
     expect(getResultMessage(errorResult(errorKind)).title).toBe(title);
   });
 
+  it("does not report an incomplete empty search as an absence of commits", () => {
+    const message = getResultMessage({ ...errorResult("empty"), incomplete: true });
+
+    expect(message.title).not.toBe("No public commits found.");
+    expect(message.title).toBe("GitHub could not finish this search.");
+    expect(message.description).toMatch(/try again/i);
+  });
+
   it("falls back to the result error text for unknown kinds", () => {
     const message = getResultMessage(errorResult("unknown", "Boom"));
     expect(message.title).toBe("We could not complete that search.");
@@ -44,6 +52,10 @@ describe("canRetryCommitSearch", () => {
 
   it.each(["empty", "validation"] as const)("does not allow retry for %s", (errorKind) => {
     expect(canRetryCommitSearch(errorResult(errorKind))).toBe(false);
+  });
+
+  it("allows retry for an incomplete empty search, which is unfinished rather than answered", () => {
+    expect(canRetryCommitSearch({ ...errorResult("empty"), incomplete: true })).toBe(true);
   });
 
   it("returns false when there is no result", () => {

--- a/app/home/resultMessages.ts
+++ b/app/home/resultMessages.ts
@@ -32,11 +32,19 @@ export function getResultMessage(result: CommitData): ResultMessage {
           "Check the username and try again. GitHub may reject searches for users that do not exist or cannot be searched.",
       };
     case "empty":
-      return {
-        title: "No public commits found.",
-        description:
-          "Try another username or check back later; GitHub commit search indexing can lag.",
-      };
+      // An incomplete search proves nothing about whether commits exist, so it must not
+      // be reported as an absence of them.
+      return result.incomplete
+        ? {
+            title: "GitHub could not finish this search.",
+            description:
+              "The search timed out before scanning every commit, so nothing came back yet. Try again in a moment.",
+          }
+        : {
+            title: "No public commits found.",
+            description:
+              "Try another username or check back later; GitHub commit search indexing can lag.",
+          };
     default:
       return {
         title: "We could not complete that search.",
@@ -47,6 +55,7 @@ export function getResultMessage(result: CommitData): ResultMessage {
 
 export function canRetryCommitSearch(result: CommitData | null) {
   return (
+    Boolean(result?.incomplete) ||
     result?.errorKind === "rate_limit" ||
     result?.errorKind === "timeout" ||
     result?.errorKind === "unavailable" ||

--- a/app/home/searchExecution.test.ts
+++ b/app/home/searchExecution.test.ts
@@ -89,6 +89,22 @@ describe("runCommitSearch", () => {
       found: true,
       error_kind: "none",
       commit_count: 1,
+      incomplete: false,
+    });
+  });
+
+  it("reports partial results in the completion event", async () => {
+    vi.mocked(getCommits).mockResolvedValue({ ...foundResult, incomplete: true });
+    const { handlers, settle } = createHandlers();
+
+    runCommitSearch("octocat", {}, handlers);
+    await settle();
+
+    expect(trackAppEvent).toHaveBeenCalledWith("search_completed", {
+      found: true,
+      error_kind: "none",
+      commit_count: 1,
+      incomplete: true,
     });
   });
 
@@ -130,6 +146,7 @@ describe("runCommitSearch", () => {
       found: false,
       error_kind: "empty",
       commit_count: 0,
+      incomplete: false,
     });
   });
 
@@ -153,6 +170,7 @@ describe("runCommitSearch", () => {
       found: false,
       error_kind: "unknown",
       commit_count: 0,
+      incomplete: false,
     });
     expect(JSON.stringify(handlers.setResult.mock.calls)).not.toContain("octocat");
     expect(JSON.stringify(handlers.setResult.mock.calls)).not.toContain("secret");
@@ -211,6 +229,7 @@ describe("runCommitSearch", () => {
       found: true,
       error_kind: "none",
       commit_count: 1,
+      incomplete: false,
     });
   });
 });

--- a/app/home/searchExecution.ts
+++ b/app/home/searchExecution.ts
@@ -61,6 +61,7 @@ export function runCommitSearch(
       found: data.found,
       error_kind: data.errorKind ?? "none",
       commit_count: data.commits.length,
+      incomplete: Boolean(data.incomplete),
     });
     if (data.found) {
       setRecentSearches((currentSearches) => {

--- a/app/home/sharedSearch.test.ts
+++ b/app/home/sharedSearch.test.ts
@@ -63,6 +63,15 @@ describe("buildResultShareText", () => {
     expect(text).toContain("Commit: https://github.com/octocat/repo/commit/abc123");
   });
 
+  it("does not call a partial result the first public commit", () => {
+    const result: CommitData = { found: true, incomplete: true, commits: [commit] };
+    const text = buildResultShareText("octocat", result);
+
+    expect(text).not.toContain("octocat's first public commit:");
+    expect(text).toContain("octocat's earliest public commit found so far: Initial commit");
+    expect(text).toContain("GitHub search was incomplete, so an earlier commit may exist.");
+  });
+
   it("falls back to a search summary when there are no commits", () => {
     const result: CommitData = { found: false, commits: [] };
     expect(buildResultShareText("octocat", result)).toContain(

--- a/app/home/sharedSearch.ts
+++ b/app/home/sharedSearch.ts
@@ -26,11 +26,17 @@ export function buildResultShareText(username: string, result: CommitData) {
   }
 
   const firstLine = firstCommit.message.split("\n")[0];
+  const summary = result.incomplete
+    ? `${username}'s earliest public commit found so far: ${firstLine}`
+    : `${username}'s first public commit: ${firstLine}`;
 
   return [
-    `${username}'s first public commit: ${firstLine}`,
+    summary,
     `Repository: ${firstCommit.repository.full_name}`,
     `Commit: ${firstCommit.html_url}`,
+    ...(result.incomplete
+      ? ["Note: GitHub search was incomplete, so an earlier commit may exist."]
+      : []),
     `Search: ${window.location.href}`,
   ].join("\n");
 }

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -108,6 +108,7 @@ describe("Home", () => {
       found: true,
       error_kind: "none",
       commit_count: 1,
+      incomplete: false,
     });
     expect(mockTrack.mock.calls.flatMap((call) => Object.values(call[1] ?? {}))).not.toContain(
       "octo",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -212,6 +212,7 @@ export default function Home() {
             commits={result.commits}
             lastSearchedUsername={lastSearchedUsername}
             shareStatus={shareStatus}
+            isIncomplete={Boolean(result.incomplete)}
             onCopy={copyResult}
           />
         ) : null}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ My First Commit is a small Next.js App Router application. It has no database, n
 3. The client validates the username format before submitting.
 4. The client calls the `getCommits` server action in `app/actions.ts`.
 5. The server action queries GitHub's public commit search through Octokit.
-6. Successful and empty GitHub search results are cached briefly in memory by normalized username to reduce repeated API calls.
+6. Successful and empty GitHub search results are cached briefly in memory by normalized username to reduce repeated API calls. Results GitHub marked `incomplete_results` are never cached, so a retry can reach a complete answer.
 7. The server action maps GitHub results into the app's `CommitData` shape.
 8. The client renders the first public commit and the next several commits in `FirstCommitDisplay`.
 9. Successful searches are stored in browser `localStorage` as recent-search shortcuts.
@@ -37,6 +37,7 @@ My First Commit is a small Next.js App Router application. It has no database, n
 GitHub API failures are normalized in `app/actions.ts`:
 
 - Empty public search results show a polite empty state.
+- GitHub sets `incomplete_results` when a commit search times out before scanning every commit, and still returns `200` with a partial item list. Those results carry `incomplete: true` through `CommitData`: the UI presents them as the earliest commit found so far rather than the first commit and explains that searching again may reach the full history, and the cache refuses to store them so that a repeated search can. An incomplete search that returned no items is reported as an unfinished search, never as an absence of commits.
 - Rate limits, timeouts, unavailable GitHub services, validation failures, and unknown errors show recovery-focused copy.
 - Server-side failures are logged with structured event names and sanitized fields only, without usernames, tokens, or raw Octokit error objects.
 

--- a/docs/manual-qa.md
+++ b/docs/manual-qa.md
@@ -48,8 +48,9 @@ production until a person looks. After a release:
    GitHub Search API with the production `GITHUB_TOKEN`.
 2. Search a username with no indexed public commits and confirm the empty state explains that GitHub
    indexing can lag.
-3. Rate-limit and outage states cannot be triggered on demand in production; they depend on GitHub.
-   Local coverage already asserts their retry actions and recovery copy through the `e2e-rate-limit`
-   and `e2e-unavailable` fixtures, so do not retest them by hand. Confirm real behavior from Vercel
-   logs after the next live failure.
+3. Rate-limit, outage, and partial-result states cannot be triggered on demand in production; they
+   depend on GitHub. Local coverage already asserts their retry actions and recovery copy through
+   the `e2e-rate-limit`, `e2e-unavailable`, `e2e-incomplete`, and `e2e-incomplete-empty` fixtures,
+   so do not retest them by hand. Confirm real behavior from Vercel logs after the next live
+   failure, where a partial result appears as a `github_commit_search_incomplete` event.
 4. Confirm the result timeline renders a real commit with its message, date, and repository link.

--- a/docs/production.md
+++ b/docs/production.md
@@ -199,6 +199,13 @@ GitHub API failures are logged with structured event names:
 - `github_commit_search_unavailable`
 - `github_commit_search_failed`
 - `github_commit_search_malformed_item`
+- `github_commit_search_incomplete`
+
+`github_commit_search_incomplete` is not a failure. GitHub returned `incomplete_results`, meaning it
+abandoned the search before scanning every commit and returned whatever it had indexed. The app
+labels that result partial and deliberately does not cache it, so a rise in this event means
+visitors are seeing partial results rather than that searches are erroring. An `itemCount` of `0`
+means the search returned nothing and the visitor saw the unfinished-search state instead.
 
 Useful fields include:
 
@@ -207,6 +214,7 @@ Useful fields include:
 - `rateLimitRemaining`
 - `rateLimitReset`
 - `itemIndex`
+- `itemCount`
 
 Upstream error messages are used only to classify failures and are not logged. Rate-limit metadata
 is logged only when header values are valid non-negative integers. Search usernames, request URLs,

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -48,11 +48,20 @@ function captureReactRenderErrors(page: Page) {
 
 async function getTextContrastRatio(locator: Locator) {
   return locator.evaluate((element) => {
-    const parseRgb = (color: string) =>
-      color
-        .match(/[\d.]+/g)!
-        .slice(0, 3)
-        .map(Number);
+    // Resolve through a canvas rather than parsing the string: Tailwind 4 serializes its
+    // palette as `lab()`, whose digits are not sRGB channels. Reading them as though they
+    // were reports a wrong ratio in both directions -- it once passed a 9.1:1 button as
+    // 16.4:1 while failing an 8.8:1 panel as 1.2:1.
+    const parseRgb = (color: string) => {
+      const canvas = document.createElement("canvas");
+      canvas.width = 1;
+      canvas.height = 1;
+      const context = canvas.getContext("2d")!;
+      context.fillStyle = color;
+      context.fillRect(0, 0, 1, 1);
+      const [red, green, blue] = context.getImageData(0, 0, 1, 1).data;
+      return [red!, green!, blue!];
+    };
     const relativeLuminance = (color: string) => {
       const channels = parseRgb(color).map((channel) => {
         const normalized = channel / 255;
@@ -467,6 +476,37 @@ test.describe("local mocked commit search states", () => {
     expect(renderErrors).toEqual([]);
   });
 
+  test("home page flags a partial result instead of claiming a first commit", async ({ page }) => {
+    await searchForUsername(page, "e2e-incomplete");
+
+    await expect(
+      page.getByRole("heading", { name: "Earliest public commit found so far" }),
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "First public commit found" })).toHaveCount(0);
+
+    const partialResultRegion = page.getByRole("region", {
+      name: "GitHub returned a partial result",
+    });
+    await expect(partialResultRegion).toBeVisible();
+    await expect(partialResultRegion).toContainText(/an earlier commit may be missing/i);
+    await expect(page.getByRole("link", { name: "Initial public commit" })).toBeVisible();
+
+    // The caveat is announced through the heading that takes focus, not a live region.
+    const partialResultHeading = page.getByRole("heading", {
+      name: "Earliest public commit found so far",
+    });
+    await expect(partialResultHeading).toBeFocused();
+    const descriptionId = await partialResultHeading.getAttribute("aria-describedby");
+    expect(descriptionId).toBeTruthy();
+    await expect(page.locator(`#${descriptionId}`)).toContainText(
+      /an earlier commit may be missing/i,
+    );
+
+    // The amber panel is a new surface in this palette; assert it clears AA rather than
+    // trusting that it looks fine.
+    expect(await getTextContrastRatio(partialResultRegion)).toBeGreaterThanOrEqual(4.5);
+  });
+
   test("home page renders a helpful empty search state", async ({ page }) => {
     await searchForUsername(page, "e2e-empty");
 
@@ -478,6 +518,20 @@ test.describe("local mocked commit search states", () => {
       page.getByRole("button", { name: "Search example username octocat" }),
     ).toBeVisible();
     await expect(page.getByRole("button", { name: "Edit username" })).toBeVisible();
+  });
+
+  test("home page distinguishes an unfinished search from an empty one", async ({ page }) => {
+    await searchForUsername(page, "e2e-incomplete-empty");
+
+    await expect(
+      page.getByRole("heading", { name: "GitHub could not finish this search." }),
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "No public commits found." })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+    // Suggesting other profiles would imply this username was searched and came up empty.
+    await expect(page.getByRole("heading", { name: "Check a known public profile" })).toHaveCount(
+      0,
+    );
   });
 
   test("home page renders retry guidance for rate limits", async ({ page }) => {


### PR DESCRIPTION
Closes #101.

## Problem

GitHub abandons a commit search that runs too long and still returns `200` with whatever it had indexed so far, setting `incomplete_results: true`. `app/actions.ts` ignored that flag, so the app labelled the first returned item "First public commit found" and cached it as authoritative for five minutes. The app's central claim was being made on evidence GitHub had explicitly marked as partial.

The empty case was the subtler half: `getResultMessage` mapped `errorKind: "empty"` to "No public commits found" regardless of cause, so a search that timed out *before it looked* told the visitor they had no public commits, and offered them a list of other people's usernames to try instead.

## What changed

- `CommitData` carries `incomplete`, set from `incomplete_results` and logged as a sanitized `github_commit_search_incomplete` event with an item count only.
- `setCachedCommitSearch` refuses incomplete results outright, so a partial answer is neither served as definitive for the TTL nor able to evict a complete result already cached for that user.
- The results view reads "Earliest public commit found so far" and explains the limitation in a labelled `<section>` that the focused `<h1>` points at with `aria-describedby` — chosen over a live region, which screen readers often skip when the block mounts with its content already inside it.
- An unfinished search that returned nothing is reported as unfinished, is retryable, and withholds the "check a known public profile" suggestions.
- Copied share text no longer calls a partial result someone's "first public commit".
- `search_completed` carries `incomplete`, so the new path is measurable.

## Deliberately not included

An in-place "Search again" button in the results view. It is the first control this app would place inside a successful result view that re-issues a search, and it needs its own state ownership (distinct from `isPending`), a pending announcement, and failure handling that does not discard the result being read. Follow-up issue filed. The empty-result path still offers "Try again" through the existing, well-tested error-state pattern.

## Testing

Complete gate passes: `npm audit`, 211 unit tests, 25 Playwright journeys, lint, format, agent-docs, labels, production build.

New coverage: incomplete flagging, the log event, and the no-cache guarantee in `app/actions.test.ts`; cache rejection and non-eviction in `app/commitSearchCache.test.ts`; the empty-vs-unfinished split in `app/home/resultMessages.test.ts`; the share caveat in `app/home/sharedSearch.test.ts`; the analytics field in `app/home/searchExecution.test.ts`; and two new component suites for surfaces that had none. Two browser journeys cover the partial and unfinished-empty states, including an AA contrast check on the new panel.

`tests/e2e/home.spec.ts`'s `getTextContrastRatio` was parsing digits out of the computed color string, which is wrong for the `lab()` values Tailwind 4 emits — it reported a 9.1:1 button as 16.4:1 and an 8.8:1 panel as 1.2:1. It now resolves colors through a canvas, which also corrects the pre-existing assertion that used it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)