### PR TITLE
feat(ui): offer an in-place retry for partial commit results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,12 @@ drift. Run the individual commands above when a scoped rerun is enough, per step
 
 - **E2E mocks.** `E2E_COMMIT_SEARCH_MOCKS=1` makes `app/actions.ts` return fixtures for the reserved
   usernames `e2e-result`, `e2e-slow-result`, `e2e-reject-once-*`, `e2e-malformed-dates`,
-  `e2e-incomplete`, `e2e-incomplete-empty`, `e2e-empty`, `e2e-rate-limit`, and `e2e-unavailable`.
-  Playwright sets this automatically and runs the app on port **3100**, not 3000. Add new fixture
-  cases in `app/actions.ts` when adding browser coverage for a new state.
+  `e2e-incomplete`, `e2e-incomplete-once-*`, `e2e-incomplete-then-error-*`, `e2e-incomplete-empty`,
+  `e2e-empty`, `e2e-rate-limit`, and `e2e-unavailable`. Playwright sets this automatically and runs
+  the app on port **3100**, not 3000. Add new fixture cases in `app/actions.ts` when adding browser
+  coverage for a new state. The `*-once-*` and `*-then-error-*` fixtures are stateful per process,
+  so a test can prove a retry re-issued the search rather than re-rendered: give each such test a
+  unique username, as the existing ones do with the Playwright worker index.
 - **Prettier ignores `*.md`.** Prose is formatted by hand. Do not run the formatter over docs, and do
   not reflow markdown as part of an unrelated change.
 - **The commit cache is per-process.** It is a plain `Map`, so it resets on every serverless cold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ## Unreleased
 
+### Added
+
+- Partial commit results now offer a **Search again** button in place. A retry that succeeds replaces the partial result, one that comes back partial again says so, and one that fails leaves the commits on screen and explains why instead of replacing them with an error screen. Each outcome is announced to assistive technology.
+
 ### Fixed
 
+- Abandoning a running search by resetting the page or starting a new one now stops it, so its result can no longer appear over the page you moved to and the search form no longer stays disabled until the abandoned request gives up.
 - A commit search that GitHub abandoned before scanning every commit is now labelled a partial result rather than "First public commit found", explains that an earlier commit may be missing, and is never cached, so searching again can reach the full history. An unfinished search that returned nothing is reported as unfinished instead of as an absence of commits, offers a retry, and no longer suggests checking a different profile. Copied result text carries the same caveat.
 - Primary green actions now meet WCAG AA text contrast, and successful searches move focus to the result heading for a clear assistive-technology transition.
 - GitHub search failure logs now exclude raw upstream messages and accept only validated numeric rate-limit metadata.

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -16,6 +16,9 @@ const E2E_COMMIT_SEARCH_MOCKS_ENABLED = process.env.E2E_COMMIT_SEARCH_MOCKS === 
 const E2E_SLOW_SEARCH_DELAY_MS = 750;
 const E2E_REJECT_ONCE_USERNAME_PREFIX = "e2e-reject-once-";
 const e2eRejectedUsernames = new Set<string>();
+const E2E_INCOMPLETE_ONCE_USERNAME_PREFIX = "e2e-incomplete-once-";
+const E2E_INCOMPLETE_THEN_ERROR_USERNAME_PREFIX = "e2e-incomplete-then-error-";
+const e2eServedPartialUsernames = new Set<string>();
 const EMPTY_COMMIT_SEARCH_MESSAGE =
   "No public commits found for this user (or indexing is delayed).";
 const INCOMPLETE_COMMIT_SEARCH_MESSAGE =
@@ -68,28 +71,30 @@ function getE2eCommitSearchResult(username: string): CommitData | null {
     },
   };
 
+  const completeResult = (): CommitData => ({
+    found: true,
+    commits: [
+      mockCommit,
+      {
+        ...mockCommit,
+        message: "Follow-up commit",
+        html_url: "https://github.com/e2e-user/next-repo/commit/bcdefa234567",
+        sha: "bcdefa234567",
+        repository: {
+          name: "next-repo",
+          owner: "e2e-user",
+          full_name: "e2e-user/next-repo",
+        },
+      },
+    ],
+  });
+
   if (
     username === "e2e-result" ||
     username === "e2e-slow-result" ||
     username.startsWith(E2E_REJECT_ONCE_USERNAME_PREFIX)
   ) {
-    return {
-      found: true,
-      commits: [
-        mockCommit,
-        {
-          ...mockCommit,
-          message: "Follow-up commit",
-          html_url: "https://github.com/e2e-user/next-repo/commit/bcdefa234567",
-          sha: "bcdefa234567",
-          repository: {
-            name: "next-repo",
-            owner: "e2e-user",
-            full_name: "e2e-user/next-repo",
-          },
-        },
-      ],
-    };
+    return completeResult();
   }
 
   if (username === "e2e-incomplete") {
@@ -98,6 +103,31 @@ function getE2eCommitSearchResult(username: string): CommitData | null {
       incomplete: true,
       commits: [mockCommit],
     };
+  }
+
+  // Stateful, so a browser test can prove a retry re-issues the search rather than
+  // re-rendering the same state: partial first, then the outcome the prefix names.
+  if (
+    username.startsWith(E2E_INCOMPLETE_ONCE_USERNAME_PREFIX) ||
+    username.startsWith(E2E_INCOMPLETE_THEN_ERROR_USERNAME_PREFIX)
+  ) {
+    if (!e2eServedPartialUsernames.has(username)) {
+      e2eServedPartialUsernames.add(username);
+      return {
+        found: true,
+        incomplete: true,
+        commits: [mockCommit],
+      };
+    }
+
+    if (username.startsWith(E2E_INCOMPLETE_THEN_ERROR_USERNAME_PREFIX)) {
+      return commitSearchError(
+        "GitHub rate limit reached. Please try again in a few minutes.",
+        "rate_limit",
+      );
+    }
+
+    return completeResult();
   }
 
   if (username === "e2e-malformed-dates") {

--- a/app/home/SearchResults.test.tsx
+++ b/app/home/SearchResults.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 import type { CommitInfo } from "../commitTypes";
 import SearchResults from "./SearchResults";
 
@@ -22,26 +23,50 @@ const commits: CommitInfo[] = [
   },
 ];
 
-function renderSearchResults(overrides: Partial<Parameters<typeof SearchResults>[0]> = {}) {
-  render(
+type Overrides = {
+  isIncomplete?: boolean;
+  commits?: CommitInfo[];
+  lastSearchedUsername?: string;
+  retry?: Partial<Parameters<typeof SearchResults>[0]["retry"]>;
+};
+
+function renderSearchResults({
+  isIncomplete = false,
+  commits: initialCommits = commits,
+  lastSearchedUsername = "octo",
+  retry = {},
+}: Overrides = {}) {
+  const onRetry = vi.fn();
+  const element = (overrides: Overrides = {}) => (
     <SearchResults
-      commits={commits}
-      lastSearchedUsername="octo"
+      commits={overrides.commits ?? initialCommits}
+      lastSearchedUsername={overrides.lastSearchedUsername ?? lastSearchedUsername}
       shareStatus=""
-      isIncomplete={false}
+      isIncomplete={overrides.isIncomplete ?? isIncomplete}
+      retry={{
+        isRetrying: false,
+        error: "",
+        stillPartial: false,
+        onRetry,
+        ...retry,
+        ...overrides.retry,
+      }}
       onCopy={() => {}}
-      {...overrides}
-    />,
+    />
   );
+  const { rerender } = render(element());
+
+  return { onRetry, rerender: (overrides: Overrides) => rerender(element(overrides)) };
 }
 
 describe("SearchResults", () => {
-  it("presents a complete result as the first public commit", () => {
+  it("presents a complete result as the first public commit, with no retry", () => {
     renderSearchResults();
 
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       "First public commit found",
     );
+    expect(screen.queryByRole("button", { name: "Search again" })).not.toBeInTheDocument();
   });
 
   it("does not claim a partial result is the first commit", () => {
@@ -71,5 +96,135 @@ describe("SearchResults", () => {
     renderSearchResults();
 
     expect(screen.getByRole("heading", { level: 1 })).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("retries the same username", async () => {
+    const user = userEvent.setup();
+    const { onRetry } = renderSearchResults({ isIncomplete: true });
+
+    await user.click(screen.getByRole("button", { name: "Search again" }));
+
+    expect(onRetry).toHaveBeenCalledWith("octo");
+  });
+
+  it("keeps a live region mounted while idle, so a later announcement is not missed", () => {
+    renderSearchResults({ isIncomplete: true });
+
+    // A region inserted together with its text is commonly not announced at all.
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toBeEmptyDOMElement();
+  });
+
+  it("reports progress and refuses a second retry while one is running", async () => {
+    const user = userEvent.setup();
+    const { onRetry } = renderSearchResults({ isIncomplete: true, retry: { isRetrying: true } });
+
+    const retryButton = screen.getByRole("button", { name: "Searching again..." });
+
+    // aria-disabled keeps the pressed control focusable; a disabled button blurs itself.
+    expect(retryButton).toHaveAttribute("aria-disabled", "true");
+    expect(retryButton).not.toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent(/searching github again for octo/i);
+
+    await user.click(retryButton);
+
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("shows a retry that finished but is still partial, not only to a screen reader", () => {
+    renderSearchResults({ isIncomplete: true, retry: { stillPartial: true } });
+
+    // Nothing else on screen changes in this case, so silence reads as a broken button.
+    expect(screen.getByRole("status")).toHaveTextContent(/still returned a partial result/i);
+    // toBeVisible passes for sr-only text, which is clipped rather than hidden.
+    expect(screen.getByText(/still returned a partial result/i)).not.toHaveClass("sr-only");
+  });
+
+  it("keeps focus on the retry button when a retry comes back partial again", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderSearchResults({ isIncomplete: true });
+
+    await user.click(screen.getByRole("button", { name: "Search again" }));
+    const retryButton = screen.getByRole("button", { name: "Search again" });
+    retryButton.focus();
+
+    // A still-partial retry returns a fresh object for the same commit; focusing the
+    // heading on that identity change would throw the visitor back to the top of the
+    // result and drown the one announcement explaining what happened.
+    rerender({
+      isIncomplete: true,
+      commits: commits.map((commit) => ({ ...commit })),
+      retry: { stillPartial: true },
+    });
+
+    expect(retryButton).toHaveFocus();
+  });
+
+  it("moves focus to the heading when a retry reaches the complete history", () => {
+    const { rerender } = renderSearchResults({ isIncomplete: true });
+
+    // Focus must start somewhere else, or this passes on the focus the mount effect set.
+    screen.getByRole("button", { name: "Search again" }).focus();
+
+    // The retry button unmounts with the panel, so without this the visitor is dropped
+    // at the top of the document with nothing announcing the outcome they asked for.
+    rerender({ isIncomplete: false, commits: commits.map((commit) => ({ ...commit })) });
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveFocus();
+  });
+
+  it("moves focus to the heading when the same commit is shown for a different username", () => {
+    const { rerender } = renderSearchResults({ isIncomplete: true });
+
+    screen.getByRole("button", { name: "Search again" }).focus();
+
+    // Two people can share an earliest commit, so the sha alone does not prove the
+    // result is unchanged.
+    rerender({ isIncomplete: true, lastSearchedUsername: "torvalds" });
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveFocus();
+  });
+
+  it("explains a failed retry without disturbing the commits already on screen", () => {
+    renderSearchResults({
+      isIncomplete: true,
+      retry: { error: "GitHub is rate limiting searches right now." },
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(/rate limiting/i);
+    expect(screen.getByText(/still the earlier partial result/i)).not.toHaveClass("sr-only");
+    expect(screen.getByRole("link", { name: "Initial commit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Search again" })).toBeInTheDocument();
+  });
+
+  it("renders a failed retry after the button, so the button does not move under the pointer", () => {
+    renderSearchResults({
+      isIncomplete: true,
+      retry: { error: "GitHub is rate limiting searches right now." },
+    });
+
+    const retryButton = screen.getByRole("button", { name: "Search again" });
+    const failure = screen.getByText(/still the earlier partial result/i);
+
+    expect(
+      retryButton.compareDocumentPosition(failure) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("adds a failed retry to the heading description, for a visitor who returns to it", () => {
+    renderSearchResults({
+      isIncomplete: true,
+      retry: { error: "GitHub is rate limiting searches right now." },
+    });
+
+    const describedBy = screen.getByRole("heading", { level: 1 }).getAttribute("aria-describedby");
+    const described = describedBy!
+      .split(" ")
+      .map((id) => document.getElementById(id)?.textContent ?? "")
+      .join(" ");
+
+    expect(described).toMatch(/earlier commit may be missing/i);
+    expect(described).toMatch(/rate limiting/i);
   });
 });

--- a/app/home/SearchResults.tsx
+++ b/app/home/SearchResults.tsx
@@ -6,12 +6,21 @@ import type { CommitInfo } from "../commitTypes";
 
 const PARTIAL_RESULT_HEADING_ID = "partial-result-heading";
 const PARTIAL_RESULT_DESCRIPTION_ID = "partial-result-description";
+const RETRY_OUTCOME_ID = "partial-result-retry-outcome";
+
+type PartialResultRetry = {
+  isRetrying: boolean;
+  error: string;
+  stillPartial: boolean;
+  onRetry: (username: string) => void;
+};
 
 type SearchResultsProps = {
   commits: CommitInfo[];
   lastSearchedUsername: string;
   shareStatus: string;
   isIncomplete: boolean;
+  retry: PartialResultRetry;
   onCopy: () => void;
 };
 
@@ -20,18 +29,34 @@ export default function SearchResults({
   lastSearchedUsername,
   shareStatus,
   isIncomplete,
+  retry,
   onCopy,
 }: SearchResultsProps) {
   const resultHeadingRef = useRef<HTMLHeadingElement>(null);
   const firstCommit = commits[0];
 
+  // Keyed on what changed rather than on object identity: a retry that comes back partial
+  // again returns a fresh object for the same commit, and focusing the heading on that
+  // would throw the visitor back to the top of the result and drown the announcement
+  // explaining what just happened.
+  const firstCommitSha = firstCommit?.sha;
   useEffect(() => {
-    if (firstCommit) resultHeadingRef.current?.focus();
-  }, [firstCommit, lastSearchedUsername]);
+    if (firstCommitSha) resultHeadingRef.current?.focus();
+  }, [firstCommitSha, lastSearchedUsername, isIncomplete]);
 
   if (!firstCommit) return null;
 
   const uniqueRepositoryCount = new Set(commits.map((commit) => commit.repository.full_name)).size;
+  // A retry changes nothing else on screen when it comes back still partial, so every
+  // outcome is spoken here rather than left to be inferred from the button's label.
+  const retryOutcome = retry.error
+    ? `${retry.error} The commits below are still the earlier partial result.`
+    : retry.stillPartial
+      ? "Searched again. GitHub still returned a partial result, so an earlier commit may still be missing."
+      : "";
+  const headingDescription = [PARTIAL_RESULT_DESCRIPTION_ID, retryOutcome ? RETRY_OUTCOME_ID : null]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 w-full flex flex-col items-center pb-12 pt-8">
@@ -39,7 +64,7 @@ export default function SearchResults({
         <h1
           ref={resultHeadingRef}
           tabIndex={-1}
-          aria-describedby={isIncomplete ? PARTIAL_RESULT_DESCRIPTION_ID : undefined}
+          aria-describedby={isIncomplete ? headingDescription : undefined}
           className="rounded-sm text-2xl font-bold text-[var(--github-gray-dark)] focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2"
         >
           {isIncomplete ? "Earliest public commit found so far" : "First public commit found"}
@@ -69,13 +94,43 @@ export default function SearchResults({
             <h2 id={PARTIAL_RESULT_HEADING_ID} className="text-base font-semibold">
               GitHub returned a partial result
             </h2>
-            {/* States the fact rather than instructing a retry: this view offers no search
-                control, so an instruction would send the visitor to the header's "Search
-                another user", which clears the very handle they were told to reuse. */}
+            {/* Sets up the button directly below it. Pointing at the header's "Search
+                another user" instead would clear the very handle being reused. */}
             <p id={PARTIAL_RESULT_DESCRIPTION_ID} className="mt-2 text-sm break-words">
               The search timed out before scanning every commit, so an earlier commit may be
-              missing. A repeated search for @{lastSearchedUsername} often reaches the full history.
+              missing. Searching again often reaches the full history.
             </p>
+            <button
+              type="button"
+              onClick={() => {
+                if (retry.isRetrying) return;
+                retry.onRetry(lastSearchedUsername);
+              }}
+              // aria-disabled rather than disabled: a disabled control loses focus the
+              // moment it is pressed, stranding a keyboard user mid-action.
+              aria-disabled={retry.isRetrying}
+              className="mt-4 inline-flex items-center justify-center rounded-md border border-amber-700 bg-white px-3 py-2 text-sm font-semibold text-amber-900 transition-colors hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-[var(--github-blue)] focus:ring-offset-2 focus:ring-offset-amber-50 aria-disabled:cursor-not-allowed aria-disabled:bg-amber-50 aria-disabled:hover:bg-amber-50"
+            >
+              {retry.isRetrying ? "Searching again..." : "Search again"}
+            </button>
+            {/* One region, mounted whether or not it has anything to say: a live region
+                inserted together with its text is commonly not announced at all, and a
+                separate visible copy of the same message would be read twice. It sits
+                below the button so a wrapping message cannot push the control out from
+                under a visitor about to press it again. */}
+            <div role="status" aria-live="polite">
+              {retry.isRetrying ? (
+                <span className="sr-only">Searching GitHub again for {lastSearchedUsername}.</span>
+              ) : null}
+              {retryOutcome ? (
+                <p
+                  id={RETRY_OUTCOME_ID}
+                  className="mt-3 rounded-md border border-amber-700 bg-white p-3 text-sm font-semibold break-words"
+                >
+                  {retryOutcome}
+                </p>
+              ) : null}
+            </div>
           </section>
         ) : (
           <p className="mt-2 text-sm text-[var(--github-gray-text)]">

--- a/app/home/resultMessages.test.ts
+++ b/app/home/resultMessages.test.ts
@@ -3,6 +3,7 @@ import type { CommitData, CommitErrorKind } from "../commitTypes";
 import {
   canRetryCommitSearch,
   getResultMessage,
+  getRetryFailureMessage,
   isEmptyCommitSearchResult,
 } from "./resultMessages";
 
@@ -39,6 +40,44 @@ describe("getResultMessage", () => {
     expect(getResultMessage(errorResult("unknown")).description).toBe(
       "GitHub commit search failed. Please try again.",
     );
+  });
+});
+
+describe("getRetryFailureMessage", () => {
+  it.each([
+    [
+      "rate_limit",
+      "GitHub is rate limiting searches right now, so wait a few minutes before searching again.",
+    ],
+    ["timeout", "GitHub took too long to respond again, so give it a moment before retrying."],
+    ["unavailable", "GitHub search is still unavailable."],
+  ] as const)("returns a single clause for %s", (errorKind, message) => {
+    expect(getRetryFailureMessage(errorResult(errorKind))).toBe(message);
+  });
+
+  it("keeps recovery guidance, since the retry button stays live beside the message", () => {
+    // Pressing the button again during a rate limit is guaranteed to fail and deepens it.
+    expect(getRetryFailureMessage(errorResult("rate_limit"))).toMatch(/wait a few minutes/i);
+  });
+
+  it("does not reuse the panel copy, which is written as standalone multi-sentence prose", () => {
+    const panelDescription = getResultMessage(errorResult("rate_limit")).description;
+
+    expect(getRetryFailureMessage(errorResult("rate_limit"))).not.toBe(panelDescription);
+    expect(getRetryFailureMessage(errorResult("rate_limit"))).not.toMatch(/\.\s/);
+  });
+
+  it("does not claim nothing came back when commits are still on screen", () => {
+    // An incomplete-empty retry reports "nothing came back yet" in the panel copy, which
+    // would contradict the commits rendered directly below this message.
+    const message = getRetryFailureMessage({ ...errorResult("empty"), incomplete: true });
+
+    expect(message).not.toMatch(/nothing came back/i);
+    expect(message).toMatch(/finish/i);
+  });
+
+  it("falls back to a generic clause for unknown kinds", () => {
+    expect(getRetryFailureMessage(errorResult("unknown"))).toBe("That search did not finish.");
   });
 });
 

--- a/app/home/resultMessages.ts
+++ b/app/home/resultMessages.ts
@@ -53,6 +53,27 @@ export function getResultMessage(result: CommitData): ResultMessage {
   }
 }
 
+/**
+ * Copy for a retry that failed while an earlier partial result is still on screen.
+ * `getResultMessage` cannot be reused here: it is written as standalone panel prose,
+ * so it runs to several sentences and its empty-search wording claims nothing came
+ * back -- which would contradict the commits rendered directly below the message.
+ */
+export function getRetryFailureMessage(result: CommitData): string {
+  switch (result.errorKind) {
+    case "rate_limit":
+      return "GitHub is rate limiting searches right now, so wait a few minutes before searching again.";
+    case "timeout":
+      return "GitHub took too long to respond again, so give it a moment before retrying.";
+    case "unavailable":
+      return "GitHub search is still unavailable.";
+    case "empty":
+      return "GitHub could not finish the search again.";
+    default:
+      return "That search did not finish.";
+  }
+}
+
 export function canRetryCommitSearch(result: CommitData | null) {
   return (
     Boolean(result?.incomplete) ||

--- a/app/home/searchExecution.test.ts
+++ b/app/home/searchExecution.test.ts
@@ -47,7 +47,7 @@ function createHandlers() {
     }),
     setLastSearchedUsername: vi.fn(),
     setShareStatus: vi.fn(),
-    setResult: vi.fn(),
+    applyResult: vi.fn(),
     setRecentSearches: vi.fn(),
   };
   return { handlers, settle: () => pending };
@@ -58,19 +58,36 @@ afterEach(() => {
 });
 
 describe("runCommitSearch", () => {
-  it("ignores blank usernames", () => {
+  it("ignores blank usernames and reports that it did not start", () => {
     const { handlers } = createHandlers();
-    runCommitSearch("   ", {}, handlers);
 
+    expect(runCommitSearch("   ", {}, handlers)).toBe(false);
     expect(handlers.startTransition).not.toHaveBeenCalled();
     expect(trackAppEvent).not.toHaveBeenCalled();
   });
 
-  it("ignores invalid usernames", () => {
+  it("ignores invalid usernames and reports that it did not start", () => {
     const { handlers } = createHandlers();
-    runCommitSearch("bad_name", {}, handlers);
 
+    expect(runCommitSearch("bad_name", {}, handlers)).toBe(false);
     expect(handlers.startTransition).not.toHaveBeenCalled();
+  });
+
+  it("reports that it started so the caller can own the busy flag", () => {
+    vi.mocked(getCommits).mockResolvedValue(foundResult);
+    const { handlers } = createHandlers();
+
+    expect(runCommitSearch("octocat", {}, handlers)).toBe(true);
+  });
+
+  it("attributes a retry to its own source rather than inferring a shared link", async () => {
+    vi.mocked(getCommits).mockResolvedValue(foundResult);
+    const { handlers, settle } = createHandlers();
+
+    runCommitSearch("octocat", { source: "retry" }, handlers);
+    await settle();
+
+    expect(trackAppEvent).toHaveBeenCalledWith("search_submitted", { source: "retry" });
   });
 
   it("updates the shared URL and tracks a user-sourced search", async () => {
@@ -83,7 +100,7 @@ describe("runCommitSearch", () => {
     expect(updateSharedSearchUrl).toHaveBeenCalledWith("octocat");
     expect(handlers.setLastSearchedUsername).toHaveBeenCalledWith("octocat");
     expect(handlers.setShareStatus).toHaveBeenCalledWith("");
-    expect(handlers.setResult).toHaveBeenCalledWith(foundResult);
+    expect(handlers.applyResult).toHaveBeenCalledWith(foundResult);
     expect(trackAppEvent).toHaveBeenCalledWith("search_submitted", { source: "user" });
     expect(trackAppEvent).toHaveBeenCalledWith("search_completed", {
       found: true,
@@ -159,7 +176,7 @@ describe("runCommitSearch", () => {
     runCommitSearch("octocat", {}, handlers);
 
     await expect(settle()).resolves.toBeUndefined();
-    expect(handlers.setResult).toHaveBeenCalledWith({
+    expect(handlers.applyResult).toHaveBeenCalledWith({
       found: false,
       error: "GitHub commit search failed. Please try again.",
       errorKind: "unknown",
@@ -172,8 +189,8 @@ describe("runCommitSearch", () => {
       commit_count: 0,
       incomplete: false,
     });
-    expect(JSON.stringify(handlers.setResult.mock.calls)).not.toContain("octocat");
-    expect(JSON.stringify(handlers.setResult.mock.calls)).not.toContain("secret");
+    expect(JSON.stringify(handlers.applyResult.mock.calls)).not.toContain("octocat");
+    expect(JSON.stringify(handlers.applyResult.mock.calls)).not.toContain("secret");
   });
 
   it("ignores an earlier search that resolves after the latest request", async () => {
@@ -197,7 +214,7 @@ describe("runCommitSearch", () => {
       }),
       setLastSearchedUsername: vi.fn(),
       setShareStatus: vi.fn(),
-      setResult: vi.fn(),
+      applyResult: vi.fn(),
       setRecentSearches: vi.fn(),
     };
     let latestSearchId = 0;
@@ -221,8 +238,8 @@ describe("runCommitSearch", () => {
     await pendingSearches[0];
 
     expect(handlers.setLastSearchedUsername).toHaveBeenLastCalledWith("torvalds");
-    expect(handlers.setResult).toHaveBeenCalledOnce();
-    expect(handlers.setResult).toHaveBeenCalledWith(latestResult);
+    expect(handlers.applyResult).toHaveBeenCalledOnce();
+    expect(handlers.applyResult).toHaveBeenCalledWith(latestResult);
     expect(handlers.setRecentSearches).toHaveBeenCalledOnce();
     expect(trackAppEvent).toHaveBeenCalledTimes(3);
     expect(trackAppEvent).toHaveBeenLastCalledWith("search_completed", {

--- a/app/home/searchExecution.ts
+++ b/app/home/searchExecution.ts
@@ -7,12 +7,22 @@ import { MAX_RECENT_SEARCHES } from "./constants";
 import { saveStoredRecentSearches } from "./recentSearches";
 import { updateSharedSearchUrl } from "./sharedSearch";
 
+type SearchSource = "user" | "shared_url" | "retry";
+
+type SearchOptions = {
+  updateUrl?: boolean;
+  source?: SearchSource;
+};
+
 type SearchHandlers = {
   isLatestSearch: () => boolean;
   startTransition: TransitionStartFunction;
   setLastSearchedUsername: Dispatch<SetStateAction<string>>;
   setShareStatus: Dispatch<SetStateAction<string>>;
-  setResult: Dispatch<SetStateAction<CommitData | null>>;
+  // Takes the settled search rather than a state action: the caller decides whether a
+  // failed retry replaces what is on screen, which it cannot do from inside an updater.
+  // It is the single settle signal, so the caller can clear its own busy flag here.
+  applyResult: (result: CommitData) => void;
   setRecentSearches: Dispatch<SetStateAction<string[]>>;
 };
 
@@ -25,25 +35,30 @@ function unexpectedSearchError(): CommitData {
   };
 }
 
+/**
+ * Returns whether the search actually started. A caller that owns a busy flag must gate
+ * it on this: the guards below reject a username without ever settling, which would
+ * otherwise leave the UI busy with nothing in flight to clear it.
+ */
 export function runCommitSearch(
   searchUsername: string,
-  options: { updateUrl?: boolean } = {},
+  options: SearchOptions = {},
   {
     isLatestSearch,
     startTransition,
     setLastSearchedUsername,
     setShareStatus,
-    setResult,
+    applyResult,
     setRecentSearches,
   }: SearchHandlers,
-) {
+): boolean {
   const trimmedUsername = normalizeGitHubUsername(searchUsername);
-  if (!trimmedUsername) return;
-  if (getUsernameValidationMessage(trimmedUsername)) return;
+  if (!trimmedUsername) return false;
+  if (getUsernameValidationMessage(trimmedUsername)) return false;
   if (options.updateUrl) updateSharedSearchUrl(trimmedUsername);
 
   trackAppEvent("search_submitted", {
-    source: options.updateUrl ? "user" : "shared_url",
+    source: options.source ?? (options.updateUrl ? "user" : "shared_url"),
   });
   setLastSearchedUsername(trimmedUsername);
   setShareStatus("");
@@ -56,7 +71,7 @@ export function runCommitSearch(
     }
     if (!isLatestSearch()) return;
 
-    setResult(data);
+    applyResult(data);
     trackAppEvent("search_completed", {
       found: data.found,
       error_kind: data.errorKind ?? "none",
@@ -77,4 +92,6 @@ export function runCommitSearch(
       });
     }
   });
+
+  return true;
 }

--- a/app/home/useCommitSearch.test.ts
+++ b/app/home/useCommitSearch.test.ts
@@ -1,0 +1,324 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getCommits } from "../actions";
+import type { CommitData } from "../commitTypes";
+import { useCommitSearch } from "./useCommitSearch";
+
+vi.mock("../actions", () => ({ getCommits: vi.fn() }));
+vi.mock("./analytics", () => ({ trackAppEvent: vi.fn() }));
+
+const mockGetCommits = vi.mocked(getCommits);
+
+const foundResult: CommitData = {
+  found: true,
+  commits: [
+    {
+      message: "Initial commit",
+      date: "2020-01-02T03:04:05Z",
+      html_url: "https://github.com/octocat/repo/commit/abc123",
+      sha: "abc123",
+      repository: { name: "repo", owner: "octocat", full_name: "octocat/repo" },
+      author: {
+        login: "octocat",
+        avatar_url: "https://github.com/ghost.png",
+        html_url: "https://github.com/octocat",
+      },
+    },
+  ],
+};
+
+const partialResult: CommitData = { ...foundResult, incomplete: true };
+
+const rateLimitedResult: CommitData = {
+  found: false,
+  error: "GitHub rate limit reached. Please try again in a few minutes.",
+  errorKind: "rate_limit",
+  commits: [],
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+async function searchAndSettle(
+  result: ReturnType<typeof renderHook<ReturnType<typeof useCommitSearch>, unknown>>["result"],
+  username: string,
+  options?: Parameters<ReturnType<typeof useCommitSearch>["runSearch"]>[1],
+) {
+  await act(async () => {
+    result.current.runSearch(username, options);
+  });
+}
+
+describe("useCommitSearch busy state", () => {
+  it("is busy while a search is in flight and idle once it settles", async () => {
+    const slowSearch = createDeferred<CommitData>();
+    mockGetCommits.mockReturnValue(slowSearch.promise);
+    const { result } = renderHook(() => useCommitSearch());
+
+    expect(result.current.isSearching).toBe(false);
+
+    act(() => {
+      result.current.runSearch("octocat");
+    });
+    await waitFor(() => {
+      expect(result.current.isSearching).toBe(true);
+    });
+
+    await act(async () => {
+      slowSearch.resolve(foundResult);
+      await slowSearch.promise;
+    });
+
+    expect(result.current.isSearching).toBe(false);
+  });
+
+  it("does not become busy for a username the search layer rejects", () => {
+    const { result } = renderHook(() => useCommitSearch());
+
+    act(() => {
+      result.current.runSearch("bad_name");
+    });
+
+    // The rejected search never settles, so a busy flag set here would never clear.
+    expect(result.current.isSearching).toBe(false);
+    expect(mockGetCommits).not.toHaveBeenCalled();
+  });
+
+  it("stops being busy when a pending search is abandoned", async () => {
+    const slowSearch = createDeferred<CommitData>();
+    mockGetCommits.mockReturnValue(slowSearch.promise);
+    const { result } = renderHook(() => useCommitSearch());
+
+    act(() => {
+      result.current.runSearch("octocat");
+    });
+    await waitFor(() => {
+      expect(result.current.isSearching).toBe(true);
+    });
+
+    act(() => {
+      result.current.cancelPendingSearch();
+    });
+
+    // Otherwise the search form stays disabled and labelled "Searching..." until the
+    // abandoned request resolves, which can take the full GitHub timeout.
+    expect(result.current.isSearching).toBe(false);
+
+    await act(async () => {
+      slowSearch.resolve(foundResult);
+      await slowSearch.promise;
+    });
+
+    expect(result.current.result).toBeNull();
+    expect(result.current.isSearching).toBe(false);
+  });
+});
+
+describe("useCommitSearch concurrency", () => {
+  it("applies only the latest of two searches started in the same flush", async () => {
+    const staleResult: CommitData = {
+      found: true,
+      commits: [{ ...foundResult.commits[0]!, message: "Stale search result" }],
+    };
+    const stale = createDeferred<CommitData>();
+    const latest = createDeferred<CommitData>();
+    mockGetCommits.mockReturnValueOnce(stale.promise).mockReturnValueOnce(latest.promise);
+    const { result } = renderHook(() => useCommitSearch());
+
+    act(() => {
+      result.current.runSearch("octocat");
+      result.current.runSearch("torvalds");
+    });
+
+    await act(async () => {
+      latest.resolve(foundResult);
+      await latest.promise;
+      stale.resolve(staleResult);
+      await stale.promise;
+    });
+
+    // Both calls are synchronous, so the latest-search marker is already updated by the
+    // time the second one reads it -- which is why the ids are distinct under either
+    // computation. What this pins is the outcome: the slower first search cannot win.
+    expect(result.current.result).toEqual(foundResult);
+  });
+
+  it("does not let a rejected search orphan one already in flight", async () => {
+    const slowSearch = createDeferred<CommitData>();
+    mockGetCommits.mockReturnValue(slowSearch.promise);
+    const { result } = renderHook(() => useCommitSearch());
+
+    act(() => {
+      result.current.runSearch("octocat");
+    });
+    await waitFor(() => {
+      expect(result.current.isSearching).toBe(true);
+    });
+
+    // "bad_name" is refused by the username rule in app/username.ts, which is what makes
+    // this a rejection rather than a second search; loosening that rule would weaken this
+    // test rather than fail it.
+    // Rejected before it starts, so it must not claim the latest-search marker. Sharing
+    // one counter would let it, and the in-flight search would then be discarded without
+    // ever reaching applyResult -- leaving the form disabled with nothing to clear it.
+    act(() => {
+      result.current.runSearch("bad_name");
+    });
+
+    await act(async () => {
+      slowSearch.resolve(foundResult);
+      await slowSearch.promise;
+    });
+
+    expect(result.current.result).toEqual(foundResult);
+    expect(result.current.isSearching).toBe(false);
+  });
+});
+
+describe("useCommitSearch retry", () => {
+  it("marks only a retry as retrying, not an ordinary search", async () => {
+    const slowSearch = createDeferred<CommitData>();
+    mockGetCommits.mockReturnValue(slowSearch.promise);
+    const { result } = renderHook(() => useCommitSearch());
+
+    act(() => {
+      result.current.runSearch("octocat");
+    });
+    await waitFor(() => {
+      expect(result.current.isSearching).toBe(true);
+    });
+    expect(result.current.isRetrying).toBe(false);
+
+    await act(async () => {
+      slowSearch.resolve(partialResult);
+      await slowSearch.promise;
+    });
+
+    const slowRetry = createDeferred<CommitData>();
+    mockGetCommits.mockReturnValue(slowRetry.promise);
+
+    act(() => {
+      result.current.runSearch("octocat", { isRetry: true });
+    });
+    await waitFor(() => {
+      expect(result.current.isRetrying).toBe(true);
+    });
+
+    await act(async () => {
+      slowRetry.resolve(foundResult);
+      await slowRetry.promise;
+    });
+
+    expect(result.current.isRetrying).toBe(false);
+  });
+
+  it("keeps the displayed result when a retry fails, and explains why", async () => {
+    mockGetCommits.mockResolvedValueOnce(partialResult).mockResolvedValueOnce(rateLimitedResult);
+    const { result } = renderHook(() => useCommitSearch());
+
+    await searchAndSettle(result, "octocat");
+    expect(result.current.result).toEqual(partialResult);
+
+    await searchAndSettle(result, "octocat", { isRetry: true });
+
+    expect(result.current.result).toEqual(partialResult);
+    expect(result.current.retryError).toBe(
+      "GitHub is rate limiting searches right now, so wait a few minutes before searching again.",
+    );
+    expect(result.current.isRetrying).toBe(false);
+  });
+
+  it("reports a retry that succeeded but is still partial", async () => {
+    mockGetCommits.mockResolvedValue(partialResult);
+    const { result } = renderHook(() => useCommitSearch());
+
+    await searchAndSettle(result, "octocat");
+    expect(result.current.retryStillPartial).toBe(false);
+
+    await searchAndSettle(result, "octocat", { isRetry: true });
+
+    // Nothing else on screen changes in this case, so without this flag a completed
+    // retry is indistinguishable from a button that did nothing.
+    expect(result.current.retryStillPartial).toBe(true);
+  });
+
+  it("clears retry outcomes when a later search starts", async () => {
+    mockGetCommits
+      .mockResolvedValueOnce(partialResult)
+      .mockResolvedValueOnce(rateLimitedResult)
+      .mockResolvedValueOnce(partialResult);
+    const { result } = renderHook(() => useCommitSearch());
+
+    await searchAndSettle(result, "octocat");
+    await searchAndSettle(result, "octocat", { isRetry: true });
+    expect(result.current.retryError).not.toBe("");
+
+    await searchAndSettle(result, "octocat", { isRetry: true });
+
+    expect(result.current.retryError).toBe("");
+    expect(result.current.retryStillPartial).toBe(true);
+  });
+
+  it("replaces the result when a retry succeeds completely", async () => {
+    mockGetCommits.mockResolvedValueOnce(partialResult).mockResolvedValueOnce(foundResult);
+    const { result } = renderHook(() => useCommitSearch());
+
+    await searchAndSettle(result, "octocat");
+    await searchAndSettle(result, "octocat", { isRetry: true });
+
+    expect(result.current.result).toEqual(foundResult);
+    expect(result.current.result?.incomplete).toBeUndefined();
+    expect(result.current.retryStillPartial).toBe(false);
+  });
+
+  it("does not call a first partial answer a repeat when the retry followed an error", async () => {
+    mockGetCommits.mockResolvedValueOnce(rateLimitedResult).mockResolvedValueOnce(partialResult);
+    const { result } = renderHook(() => useCommitSearch());
+
+    await searchAndSettle(result, "octocat");
+    await searchAndSettle(result, "octocat", { isRetry: true });
+
+    expect(result.current.result).toEqual(partialResult);
+    expect(result.current.retryStillPartial).toBe(false);
+  });
+
+  it("replaces the error when a retry from the error panel fails again", async () => {
+    mockGetCommits.mockResolvedValueOnce(rateLimitedResult).mockResolvedValueOnce({
+      found: false,
+      error: "GitHub is temporarily unavailable. Please try again soon.",
+      errorKind: "unavailable",
+      commits: [],
+    });
+    const { result } = renderHook(() => useCommitSearch());
+
+    await searchAndSettle(result, "octocat");
+    await searchAndSettle(result, "octocat", { isRetry: true });
+
+    // Preservation is for a result worth keeping; there is none here, so the new error
+    // must replace the old one rather than leaving stale copy on screen.
+    expect(result.current.result?.errorKind).toBe("unavailable");
+    expect(result.current.retryError).toBe("");
+  });
+
+  it("still replaces a failed ordinary search, so only retries preserve results", async () => {
+    mockGetCommits.mockResolvedValueOnce(partialResult).mockResolvedValueOnce(rateLimitedResult);
+    const { result } = renderHook(() => useCommitSearch());
+
+    await searchAndSettle(result, "octocat");
+    await searchAndSettle(result, "octocat");
+
+    expect(result.current.result).toEqual(rateLimitedResult);
+    expect(result.current.retryError).toBe("");
+  });
+});

--- a/app/home/useCommitSearch.ts
+++ b/app/home/useCommitSearch.ts
@@ -1,23 +1,39 @@
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import type { CommitData } from "../commitTypes";
 import { clearStoredRecentSearches, getStoredRecentSearches } from "./recentSearches";
+import { getRetryFailureMessage } from "./resultMessages";
 import { runCommitSearch } from "./searchExecution";
 
-type RunSearchOptions = { updateUrl?: boolean };
+type RunSearchOptions = { updateUrl?: boolean; isRetry?: boolean };
 
 /**
  * Owns the commit-search result lifecycle (result, last-searched username,
- * recent searches, share status, and the pending transition) so the page
- * component can trigger a search with a single `runSearch` call instead of
- * threading state setters through every handler.
+ * recent searches, share status, and the busy state) so the page component can
+ * trigger a search with a single `runSearch` call instead of threading state
+ * setters through every handler.
+ *
+ * The busy flag is owned here rather than taken from `useTransition`. `isPending`
+ * stays true through the tail of a transition and through a search the visitor has
+ * abandoned, which would leave the search form disabled with nothing in flight to
+ * re-enable it.
  */
 export function useCommitSearch() {
   const [result, setResult] = useState<CommitData | null>(null);
   const [lastSearchedUsername, setLastSearchedUsername] = useState("");
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [shareStatus, setShareStatus] = useState("");
-  const [isPending, startTransition] = useTransition();
+  const [isSearching, setIsSearching] = useState(false);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [retryError, setRetryError] = useState("");
+  const [retryStillPartial, setRetryStillPartial] = useState(false);
+  const [, startTransition] = useTransition();
+  const nextSearchIdRef = useRef(0);
   const latestSearchIdRef = useRef(0);
+  const resultRef = useRef<CommitData | null>(null);
+
+  useEffect(() => {
+    resultRef.current = result;
+  }, [result]);
 
   useEffect(() => {
     const loadRecentSearches = window.setTimeout(() => {
@@ -28,16 +44,67 @@ export function useCommitSearch() {
   }, []);
 
   const runSearch = useCallback((searchUsername: string, options: RunSearchOptions = {}) => {
-    const searchId = ++latestSearchIdRef.current;
+    // Identity comes from its own counter rather than from the latest-search marker, so
+    // it cannot depend on when that marker is assigned. The marker moves separately, and
+    // only once the search actually started.
+    const searchId = ++nextSearchIdRef.current;
+    const isRetry = Boolean(options.isRetry);
 
-    runCommitSearch(searchUsername, options, {
-      isLatestSearch: () => searchId === latestSearchIdRef.current,
-      startTransition,
-      setLastSearchedUsername,
-      setShareStatus,
-      setResult,
-      setRecentSearches,
-    });
+    const started = runCommitSearch(
+      searchUsername,
+      { updateUrl: options.updateUrl, source: isRetry ? "retry" : undefined },
+      {
+        isLatestSearch: () => searchId === latestSearchIdRef.current,
+        startTransition,
+        setLastSearchedUsername,
+        setShareStatus,
+        applyResult: (data) => {
+          setIsSearching(false);
+          setIsRetrying(false);
+
+          // A retry launched from the results view must not destroy the result the
+          // visitor is reading: a shared rate limit or timeout would otherwise replace
+          // their commits with an error screen for taking the retry the UI offered.
+          if (isRetry && !data.found && resultRef.current?.found) {
+            setRetryError(getRetryFailureMessage(data));
+            return;
+          }
+
+          // "Still" is only true if the previous result was itself partial. A retry from
+          // the error panel starts from a failure, so a first partial answer there is
+          // news rather than a repeat.
+          if (isRetry && data.found && data.incomplete && resultRef.current?.incomplete) {
+            setRetryStillPartial(true);
+          }
+          setResult(data);
+        },
+        setRecentSearches,
+      },
+    );
+
+    // Only claim the search once the layer below accepted it; a rejected username
+    // never settles, so a busy flag set here would never clear.
+    if (!started) return;
+
+    // Assigned after the call, which is safe only because `isLatestSearch` is first
+    // consulted after an await. A synchronous check would read the previous value and
+    // make the search discard itself.
+    latestSearchIdRef.current = searchId;
+    setIsSearching(true);
+    setIsRetrying(isRetry);
+    setRetryError("");
+    setRetryStillPartial(false);
+  }, []);
+
+  // Reset controls clear the result but cannot clear an in-flight request. Without this
+  // a slow search resolving afterwards would remount results over the page the visitor
+  // moved to, and the busy flag would outlive the search by up to the GitHub timeout.
+  const cancelPendingSearch = useCallback(() => {
+    latestSearchIdRef.current = ++nextSearchIdRef.current;
+    setIsSearching(false);
+    setIsRetrying(false);
+    setRetryError("");
+    setRetryStillPartial(false);
   }, []);
 
   const clearRecentSearches = useCallback(() => {
@@ -54,7 +121,11 @@ export function useCommitSearch() {
     clearRecentSearches,
     shareStatus,
     setShareStatus,
-    isPending,
+    isSearching,
+    isRetrying,
+    retryError,
+    retryStillPartial,
     runSearch,
+    cancelPendingSearch,
   };
 }

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -115,6 +115,93 @@ describe("Home", () => {
     );
   });
 
+  it("keeps a partial result on screen when the retry fails", async () => {
+    mockGetCommits
+      .mockResolvedValueOnce({ ...commitResult, incomplete: true })
+      .mockResolvedValueOnce({
+        found: false,
+        error: "GitHub rate limit reached. Please try again in a few minutes.",
+        errorKind: "rate_limit",
+        commits: [],
+      });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    await screen.findByRole("heading", { name: /earliest public commit found so far/i });
+
+    await user.click(screen.getByRole("button", { name: "Search again" }));
+
+    // Losing the commits would punish the visitor for taking the retry the UI offered.
+    expect(await screen.findByText(/still the earlier partial result/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Initial commit" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /github is asking us to slow down/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("re-enables the search form when a retry is abandoned", async () => {
+    const slowRetry = createDeferred<CommitData>();
+    mockGetCommits
+      .mockResolvedValueOnce({ ...commitResult, incomplete: true })
+      .mockReturnValueOnce(slowRetry.promise);
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    await screen.findByRole("heading", { name: /earliest public commit found so far/i });
+
+    await user.click(screen.getByRole("button", { name: "Search again" }));
+    await waitFor(() => {
+      expect(mockGetCommits).toHaveBeenCalledTimes(2);
+    });
+    await user.click(screen.getByRole("button", { name: /search another user/i }));
+
+    // The abandoned request can take the full GitHub timeout to resolve; the form must
+    // not sit disabled and labelled "Searching..." until it does.
+    const searchBox = await screen.findByRole("searchbox", { name: /github username/i });
+    await user.type(searchBox, "torvalds");
+    expect(screen.getByRole("button", { name: /^search$/i })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: /searching/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/searching github for/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      slowRetry.resolve(commitResult);
+      await slowRetry.promise;
+    });
+
+    expect(
+      screen.queryByRole("heading", { name: /first public commit found/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("attributes a retry from the error panel to a retry, not to a shared link", async () => {
+    mockGetCommits
+      .mockResolvedValueOnce({
+        found: false,
+        error: "GitHub rate limit reached. Please try again in a few minutes.",
+        errorKind: "rate_limit",
+        commits: [],
+      })
+      .mockResolvedValueOnce(commitResult);
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox", { name: /github username/i }), "octo");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    await screen.findByRole("heading", { name: /github is asking us to slow down/i });
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    // Inferring the source from updateUrl would count this as a shared-link arrival,
+    // under-counting retries and inflating shared_url on the same dashboard.
+    await waitFor(() => {
+      expect(mockTrack).toHaveBeenCalledWith("search_submitted", { source: "retry" });
+    });
+  });
+
   it("copies a shareable result summary", async () => {
     mockGetCommits.mockResolvedValue(commitResult);
     const user = userEvent.setup();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,8 +32,12 @@ export default function Home() {
     clearRecentSearches,
     shareStatus,
     setShareStatus,
-    isPending,
+    isSearching,
+    isRetrying,
+    retryError,
+    retryStillPartial,
     runSearch,
+    cancelPendingSearch,
   } = useCommitSearch();
 
   const focusSearchInput = () => {
@@ -69,6 +73,7 @@ export default function Home() {
   };
 
   const resetSearch = () => {
+    cancelPendingSearch();
     setResult(null);
     setShareStatus("");
     clearSharedSearchUrl();
@@ -76,6 +81,7 @@ export default function Home() {
   };
 
   const startNewSearch = () => {
+    cancelPendingSearch();
     setResult(null);
     setUsername("");
     setLastSearchedUsername("");
@@ -90,7 +96,7 @@ export default function Home() {
   };
 
   const usernameValidationMessage = getUsernameValidationMessage(username);
-  const canSearch = Boolean(username.trim()) && !usernameValidationMessage && !isPending;
+  const canSearch = Boolean(username.trim()) && !usernameValidationMessage && !isSearching;
 
   const copyResult = async () => {
     if (!result?.found || !navigator.clipboard) {
@@ -139,7 +145,7 @@ export default function Home() {
       >
         {!result?.found ? (
           <div
-            className={`mb-8 mt-20 text-center transition-all duration-500 ${isPending ? "opacity-50" : "opacity-100"}`}
+            className={`mb-8 mt-20 text-center transition-all duration-500 ${isSearching ? "opacity-50" : "opacity-100"}`}
           >
             <h1 className="mb-4 text-3xl font-extrabold tracking-tight text-[var(--github-gray-dark)] sm:text-5xl">
               Discover your origin.
@@ -155,7 +161,7 @@ export default function Home() {
             username={username}
             validationMessage={usernameValidationMessage}
             canSearch={canSearch}
-            isPending={isPending}
+            isPending={isSearching}
             searchInputRef={searchInputRef}
             onSubmit={handleSearch}
             onUsernameChange={setUsername}
@@ -166,7 +172,7 @@ export default function Home() {
           <SearchShortcutSection
             title="Recent searches"
             usernames={recentSearches}
-            isPending={isPending}
+            isPending={isSearching}
             onSearch={handleShortcutSearch}
             getButtonLabel={(recentUsername) => `@${recentUsername}`}
             buttonAriaLabel={(recentUsername) => `Search ${recentUsername} again`}
@@ -178,14 +184,14 @@ export default function Home() {
           <SearchShortcutSection
             title="Examples"
             usernames={EXAMPLE_USERNAMES}
-            isPending={isPending}
+            isPending={isSearching}
             onSearch={handleShortcutSearch}
             getButtonLabel={(exampleUsername) => `@${exampleUsername}`}
             buttonAriaLabel={(exampleUsername) => `Search example username ${exampleUsername}`}
           />
         ) : null}
 
-        {isPending && !result ? (
+        {isSearching && !result ? (
           <div
             role="status"
             aria-live="polite"
@@ -199,9 +205,9 @@ export default function Home() {
           <SearchErrorState
             result={result}
             exampleUsernames={EXAMPLE_USERNAMES}
-            isPending={isPending}
+            isPending={isSearching}
             lastSearchedUsername={lastSearchedUsername}
-            onRetry={(searchUsername) => runSearch(searchUsername)}
+            onRetry={(searchUsername) => runSearch(searchUsername, { isRetry: true })}
             onReset={resetSearch}
             onExampleSearch={handleShortcutSearch}
           />
@@ -213,6 +219,12 @@ export default function Home() {
             lastSearchedUsername={lastSearchedUsername}
             shareStatus={shareStatus}
             isIncomplete={Boolean(result.incomplete)}
+            retry={{
+              isRetrying,
+              error: retryError,
+              stillPartial: retryStillPartial,
+              onRetry: (searchUsername) => runSearch(searchUsername, { isRetry: true }),
+            }}
             onCopy={copyResult}
           />
         ) : null}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ My First Commit is a small Next.js App Router application. It has no database, n
 GitHub API failures are normalized in `app/actions.ts`:
 
 - Empty public search results show a polite empty state.
-- GitHub sets `incomplete_results` when a commit search times out before scanning every commit, and still returns `200` with a partial item list. Those results carry `incomplete: true` through `CommitData`: the UI presents them as the earliest commit found so far rather than the first commit and explains that searching again may reach the full history, and the cache refuses to store them so that a repeated search can. An incomplete search that returned no items is reported as an unfinished search, never as an absence of commits.
+- GitHub sets `incomplete_results` when a commit search times out before scanning every commit, and still returns `200` with a partial item list. Those results carry `incomplete: true` through `CommitData`: the UI presents them as the earliest commit found so far rather than the first commit and offers a retry, and the cache refuses to store them so that a retry can reach a complete answer. A retry that fails keeps the partial result on screen rather than replacing it, since the visitor took an action the page offered. An incomplete search that returned no items is reported as an unfinished search, never as an absence of commits.
 - Rate limits, timeouts, unavailable GitHub services, validation failures, and unknown errors show recovery-focused copy.
 - Server-side failures are logged with structured event names and sanitized fields only, without usernames, tokens, or raw Octokit error objects.
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -21,13 +21,28 @@ function expectSecurityHeaders(response: APIResponse) {
   expect(headers["reporting-endpoints"]).toContain('csp-endpoint="/api/csp-report"');
 }
 
+// Fixture usernames must stay within GitHub's 39-character limit, which the client
+// validates: over it, the Search button silently stays disabled and the journey fails
+// as an unexplained click timeout rather than as a validation error.
+const MAX_GITHUB_USERNAME_LENGTH = 39;
+
 async function searchForUsername(page: Page, username: string) {
+  expect(username.length).toBeLessThanOrEqual(MAX_GITHUB_USERNAME_LENGTH);
+
   await page.goto("/");
   await page.waitForLoadState("networkidle");
 
+  // The page takes focus in a mount effect, so this is the hydration barrier.
+  // `networkidle` is not one: filling this controlled input before hydration leaves
+  // React's state empty, so the Search button never enables and the click hangs for
+  // the full timeout with no indication of why.
   const searchBox = page.getByRole("searchbox", { name: "GitHub username" });
+  await expect(searchBox).toBeFocused();
   await searchBox.fill(username);
-  await page.getByRole("button", { name: "Search", exact: true }).click();
+
+  const searchButton = page.getByRole("button", { name: "Search", exact: true });
+  await expect(searchButton).toBeEnabled();
+  await searchButton.click();
 }
 
 function captureReactRenderErrors(page: Page) {
@@ -223,6 +238,9 @@ test("home page blocks invalid usernames without leaving keyboard flow", async (
   await page.goto("/");
 
   const searchBox = page.getByRole("searchbox", { name: "GitHub username" });
+  // Same hydration barrier as searchForUsername: a pre-hydration fill leaves React's
+  // state empty, so the validation this asserts never runs.
+  await expect(searchBox).toBeFocused();
   const searchButton = page.getByRole("button", { name: "Search", exact: true });
 
   await searchBox.fill("octo_cat");
@@ -387,7 +405,11 @@ test.describe("local mocked commit search states", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    await page.getByRole("searchbox", { name: "GitHub username" }).fill("e2e-result");
+    // Same hydration barrier as searchForUsername: a pre-hydration fill leaves React's
+    // state empty, so the button never enables and this dies as an unexplained timeout.
+    const searchBox = page.getByRole("searchbox", { name: "GitHub username" });
+    await expect(searchBox).toBeFocused();
+    await searchBox.fill("e2e-result");
     const searchButton = page.getByRole("button", { name: "Search", exact: true });
     await expect(searchButton).toBeEnabled();
     expect(await getTextContrastRatio(searchButton)).toBeGreaterThanOrEqual(4.5);
@@ -496,15 +518,76 @@ test.describe("local mocked commit search states", () => {
       name: "Earliest public commit found so far",
     });
     await expect(partialResultHeading).toBeFocused();
-    const descriptionId = await partialResultHeading.getAttribute("aria-describedby");
-    expect(descriptionId).toBeTruthy();
-    await expect(page.locator(`#${descriptionId}`)).toContainText(
+    const describedBy = await partialResultHeading.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    await expect(page.locator(`#${describedBy!.split(" ")[0]}`)).toContainText(
       /an earlier commit may be missing/i,
     );
 
     // The amber panel is a new surface in this palette; assert it clears AA rather than
     // trusting that it looks fine.
     expect(await getTextContrastRatio(partialResultRegion)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test("a retry that is still partial says so and keeps focus on the button", async ({ page }) => {
+    await searchForUsername(page, "e2e-incomplete");
+
+    const retryButton = page.getByRole("button", { name: "Search again" });
+    await retryButton.click();
+
+    // The fixture is always partial, so this is the repeat-partial outcome: nothing else
+    // on screen changes, and without a message the button reads as broken.
+    await expect(page.getByText(/still returned a partial result/i)).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Earliest public commit found so far" }),
+    ).toBeVisible();
+    await expect(retryButton).toBeFocused();
+  });
+
+  test("retrying a partial result reaches the complete history", async ({ page }, testInfo) => {
+    const partialUsername = `e2e-incomplete-once-${testInfo.workerIndex}-${Date.now().toString(36)}`;
+
+    await searchForUsername(page, partialUsername);
+    await expect(
+      page.getByRole("heading", { name: "Earliest public commit found so far" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Search again" }).click();
+
+    // The fixture returns a complete result on the second call, so the panel clearing
+    // proves the retry re-issued the search rather than re-rendering the same state.
+    await expect(page.getByRole("heading", { name: "First public commit found" })).toBeVisible();
+    await expect(
+      page.getByRole("region", { name: "GitHub returned a partial result" }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("link", { name: "Follow-up commit" })).toBeVisible();
+  });
+
+  test("a failed retry keeps the partial result on screen", async ({ page }, testInfo) => {
+    const partialUsername = `e2e-incomplete-then-error-${testInfo.workerIndex}-${Date.now().toString(36)}`;
+
+    await searchForUsername(page, partialUsername);
+    const retryButton = page.getByRole("button", { name: "Search again" });
+    await expect(retryButton).toBeVisible();
+    const buttonBoxBefore = await retryButton.boundingBox();
+    expect(buttonBoxBefore).not.toBeNull();
+
+    await retryButton.click();
+
+    await expect(page.getByText(/still the earlier partial result/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: "Initial public commit" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "GitHub is asking us to slow down." }),
+    ).toHaveCount(0);
+
+    // The failure renders below the button, so the control the visitor may press again
+    // does not shift out from under them.
+    const buttonBoxAfter = await retryButton.boundingBox();
+    expect(buttonBoxAfter).not.toBeNull();
+    // Tolerance rather than equality: the claim is that the button did not move, and an
+    // exact float comparison would fail on a sub-pixel rendering difference instead.
+    expect(Math.abs(buttonBoxAfter!.y - buttonBoxBefore!.y)).toBeLessThan(1);
+    expect(await getTextContrastRatio(retryButton)).toBeGreaterThanOrEqual(4.5);
   });
 
   test("home page renders a helpful empty search state", async ({ page }) => {


### PR DESCRIPTION
Closes #138. Follow-up to #137, which shipped the partial-result labelling without this control.

## Problem

#137 told the visitor a repeated search often reaches the full history, then gave them nowhere to run one. The results view renders no search form, and the header's "Search another user" clears the handle the copy asked them to reuse. A reload works, because the URL carries `?user=`, but that is not discoverable.

## What changed

The partial-result panel carries a **Search again** button, with all three outcomes handled:

| Outcome | Behaviour |
| --- | --- |
| Reaches the full history | Replaces the partial result; focus moves to the updated heading |
| Still partial | Says so, visibly and audibly; focus stays on the button |
| Fails | Commits stay on screen, reason renders below the button |

Four things #138 recorded as the reasons this was deferred, and how each is handled:

- **Busy state** is owned by `useCommitSearch` rather than read from `useTransition`. `isPending` stays true through the tail of a transition and through an abandoned search, which would leave the form disabled with nothing in flight to re-enable it. `isSearching` is set only once the search layer accepts the username and cleared on every settle path.
- **Cancellation** — `cancelPendingSearch()` invalidates the in-flight request from both reset paths. Search identity comes from its own counter, so a rejected username cannot claim the latest-search marker and orphan a search already running — that would skip `applyResult` and strand the busy flag.
- **Failure** keeps the displayed result. `getRetryFailureMessage` gives one clause per error kind, keeping the recovery guidance, rather than reusing panel prose that would claim nothing came back while commits are visible.
- **Announcement** uses one always-mounted polite region. A region inserted together with its text is commonly not announced at all, and two regions would read the same message twice.

Also here: retries from the error panel are attributed as retries rather than inferred to be shared-link arrivals, which would have miscounted both series on any dashboard; and the results heading takes focus on what changed rather than on commit object identity, since a still-partial retry returns a fresh object for the same commit.

## Testing

Complete gate green: `npm audit`, 246 unit tests, 28 Playwright journeys, lint, format, agent-docs, labels, build.

Three new journeys cover the retry outcomes, backed by stateful `e2e-incomplete-once-*` and `e2e-incomplete-then-error-*` fixtures so a retry is proven to re-issue the search rather than re-render. Unit coverage spans the busy-flag lifecycle including abandonment and the rejected-username orphan case, retry-vs-ordinary attribution, result preservation, still-partial reporting, and both focus outcomes. Each new guard was mutation-tested — every one fails with its fix removed.

Also fixes a **pre-existing** intermittent failure in the browser tests: filling the controlled search input before hydration leaves React's state empty, so the Search button never enables and the test dies as an unexplained 30s timeout. `networkidle` is not a hydration barrier; waiting for the input to take focus is. Applied to the shared helper and the two tests that fill the input directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)