### PR TITLE
fix(storage): sanitize recent searches loaded from localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Fixed
 
+- Recent searches loaded from the browser are now sanitized before they are shown. In a corrupt stored list — hand-edited, or written by something other than this app — blank and whitespace-only entries rendered as a bare `@` shortcut that searched for nothing, values kept their surrounding whitespace, and the same handle in different capitalization appeared as two separate shortcuts. Entries are now trimmed, validated, and collapsed case-insensitively, and a corrupt list still shows the full five shortcuts a visitor has earned rather than letting junk consume the slots.
 - Abandoning a running search by resetting the page or starting a new one now stops it, so its result can no longer appear over the page you moved to and the search form no longer stays disabled until the abandoned request gives up.
 - A commit search that GitHub abandoned before scanning every commit is now labelled a partial result rather than "First public commit found", explains that an earlier commit may be missing, and is never cached, so searching again can reach the full history. An unfinished search that returned nothing is reported as unfinished instead of as an absence of commits, offers a retry, and no longer suggests checking a different profile. Copied result text carries the same caveat.
 - Primary green actions now meet WCAG AA text contrast, and successful searches move focus to the result heading for a clear assistive-technology transition.

--- a/app/home/recentSearches.test.ts
+++ b/app/home/recentSearches.test.ts
@@ -1,9 +1,85 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { RECENT_SEARCHES_STORAGE_KEY } from "./constants";
 import {
   clearStoredRecentSearches,
   getStoredRecentSearches,
   saveStoredRecentSearches,
 } from "./recentSearches";
+
+function storeRaw(value: unknown) {
+  window.localStorage.setItem(RECENT_SEARCHES_STORAGE_KEY, JSON.stringify(value));
+}
+
+describe("getStoredRecentSearches", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it.each([
+    ["an empty string", [""], []],
+    ["whitespace only", ["   "], []],
+    ["a tab and newline", ["\t\n"], []],
+    ["non-string entries", [42, null, true, {}, []], []],
+    ["an invalid username", ["not a username"], []],
+    ["a username that is too long", ["a".repeat(40)], []],
+    ["consecutive hyphens", ["octo--cat"], []],
+    ["a leading hyphen", ["-octo"], []],
+    ["surrounding whitespace", ["  octo  "], ["octo"]],
+    ["mixed valid and junk", ["", "octo", 7, "  ", "torvalds"], ["octo", "torvalds"]],
+  ])("drops or repairs %s", (_label, stored, expected) => {
+    storeRaw(stored);
+
+    expect(getStoredRecentSearches()).toEqual(expected);
+  });
+
+  it("collapses case-insensitive duplicates, keeping the first spelling", () => {
+    storeRaw(["Octo", "octo", "OCTO", "torvalds"]);
+
+    expect(getStoredRecentSearches()).toEqual(["Octo", "torvalds"]);
+  });
+
+  it("collapses duplicates that differ only by surrounding whitespace", () => {
+    storeRaw(["octo", "  octo  "]);
+
+    expect(getStoredRecentSearches()).toEqual(["octo"]);
+  });
+
+  it("caps the list after removing junk, not before", () => {
+    // Slicing first would let blanks consume slots and return fewer than the cap.
+    storeRaw(["", "a", "", "b", "", "c", "", "d", "", "e", "f"]);
+
+    // Capping first would return ["a", "b"] -- the blanks would eat three of the five slots.
+    expect(getStoredRecentSearches()).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  it("does not let collapsed duplicates consume cap slots", () => {
+    // Counting duplicates toward the cap is the same defect as counting blanks: the visitor
+    // loses a shortcut they earned. The blank case alone does not pin this.
+    storeRaw(["Octo", "octo", "a", "b", "c", "d", "e"]);
+
+    expect(getStoredRecentSearches()).toEqual(["Octo", "a", "b", "c", "d"]);
+  });
+
+  it("returns an empty list for corrupt JSON", () => {
+    window.localStorage.setItem(RECENT_SEARCHES_STORAGE_KEY, "{not json");
+
+    expect(getStoredRecentSearches()).toEqual([]);
+  });
+
+  it.each([
+    ["an object", { octo: true }],
+    ["a bare string", "octo"],
+    ["a number", 3],
+  ])("returns an empty list when the stored value is %s rather than an array", (_label, stored) => {
+    storeRaw(stored);
+
+    expect(getStoredRecentSearches()).toEqual([]);
+  });
+
+  it("returns an empty list when nothing is stored", () => {
+    expect(getStoredRecentSearches()).toEqual([]);
+  });
+});
 
 describe("recentSearches helpers", () => {
   afterEach(() => {

--- a/app/home/recentSearches.ts
+++ b/app/home/recentSearches.ts
@@ -1,4 +1,4 @@
-import { getUsernameValidationMessage } from "../username";
+import { getUsernameValidationMessage, normalizeGitHubUsername } from "../username";
 import { MAX_RECENT_SEARCHES, RECENT_SEARCHES_STORAGE_KEY } from "./constants";
 
 // Recent searches are a best-effort convenience. Reading or writing them can
@@ -6,21 +6,51 @@ import { MAX_RECENT_SEARCHES, RECENT_SEARCHES_STORAGE_KEY } from "./constants";
 // security policy); none of that should break the page, so we swallow the
 // failure and fall back to an empty/no-op result.
 
+/**
+ * Anything may be in storage: hand-edited entries, or values written by another tool using the
+ * same key. This app only ever adds a trimmed, validated handle, so junk does not originate here
+ * -- though before this sanitizer it could be re-persisted, since a blank that survived the read
+ * was written back with the rest of the list on the next successful search. Each entry is
+ * trimmed, validated, and deduplicated before it can reach the shortcut buttons.
+ *
+ * The cap is applied last. Applying it first would let junk consume slots and return fewer
+ * shortcuts than the visitor actually has.
+ */
+function sanitizeStoredSearches(storedSearches: unknown[]) {
+  const seen = new Set<string>();
+  const searches: string[] = [];
+
+  for (const storedSearch of storedSearches) {
+    if (typeof storedSearch !== "string") continue;
+
+    const username = normalizeGitHubUsername(storedSearch);
+    // `getUsernameValidationMessage` reports no problem with an empty value on purpose: the
+    // search form must not show an error before anything has been typed. Storage has no such
+    // excuse, so emptiness is rejected here rather than inferred from a missing message --
+    // that inference is what let blank entries render as bare `@` shortcuts.
+    if (!username || getUsernameValidationMessage(username)) continue;
+
+    const duplicateKey = username.toLowerCase();
+    if (seen.has(duplicateKey)) continue;
+
+    seen.add(duplicateKey);
+    searches.push(username);
+    if (searches.length === MAX_RECENT_SEARCHES) break;
+  }
+
+  return searches;
+}
+
 export function getStoredRecentSearches() {
   if (typeof window === "undefined") return [];
 
   try {
-    const storedSearches = JSON.parse(
+    const storedSearches: unknown = JSON.parse(
       window.localStorage.getItem(RECENT_SEARCHES_STORAGE_KEY) ?? "[]",
     );
     if (!Array.isArray(storedSearches)) return [];
 
-    return storedSearches
-      .filter(
-        (search): search is string =>
-          typeof search === "string" && !getUsernameValidationMessage(search),
-      )
-      .slice(0, MAX_RECENT_SEARCHES);
+    return sanitizeStoredSearches(storedSearches);
   } catch {
     return [];
   }

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -278,6 +278,29 @@ test("home page renders recent searches stored in the browser", async ({ page })
   await expect(page.getByRole("button", { name: "Search octocat again" })).toBeVisible();
 });
 
+test("home page ignores corrupt stored recent searches", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "my-first-commit:recent-searches",
+      JSON.stringify(["", "  ", "octocat", 42, "not a username", "  OCTOCAT  "]),
+    );
+  });
+
+  await page.goto("/");
+
+  // Asserting the row's visible text, because that is what the visitor reads and it is the
+  // only form that catches every case at once. Before this fix the same stored list rendered
+  // "@", "@", "@octocat", "@ OCTOCAT": blanks became bare "@" buttons that searched for
+  // nothing, and a case variant became a second button for the same person.
+  //
+  // An accessible-name assertion would not do it. These buttons carry an aria-label, so a
+  // blank entry is named "Search  again" rather than "@", and Playwright's name matching is
+  // a case-insensitive substring by default, so "Search octocat again" also matches
+  // "@OCTOCAT".
+  const recentSearches = page.getByRole("region", { name: "Recent searches" });
+  await expect(recentSearches.getByRole("button")).toHaveText(["Clear", "@octocat"]);
+});
+
 test("home page advertises branded app and social preview images", async ({ page, request }) => {
   await page.goto("/");
 


### PR DESCRIPTION
Closes #102.

## Problem

The stored list was filtered with `!getUsernameValidationMessage(value)`. That helper reports **no problem** with an empty value on purpose — the search form must not show an error before anything has been typed. The storage reader inherited that leniency, so blanks passed straight through and rendered as bare `@` shortcut buttons that searched for nothing.

Three defects from one cause:

| Stored | Rendered before | Rendered now |
| --- | --- | --- |
| `""`, `"  "` | `@` — a button that searches nothing | dropped |
| `"  octo  "` | `@  octo  ` | `@octo` |
| `"Octo"`, `"octo"` | two buttons for one person | one, first spelling kept |

The five-item cap also ran *before* filtering, so junk consumed slots and a corrupt list showed fewer shortcuts than the visitor had earned. It now runs last.

## Scope

Read path only, per the issue. The write path trims and validates before adding anything, and its only other input is a sanitized read, so nothing can reach storage unsanitized today. Both reviewers confirmed that independently; adding a second cap inside `saveStoredRecentSearches` would be a drift risk rather than defence in depth.

The sanitized list is deliberately **not** written back — every read sanitizes and this is the only reader, so a hydration write would add the operation most likely to throw in private mode or under quota, in exchange for nothing a visitor can observe.

## Testing

Complete gate green: audit, 296 unit tests, 29 journeys, lint, format, agent-docs, labels, build.

19 unit cases, mostly table-driven; the browser journey seeds a deliberately corrupt list and asserts the row's visible text.

Two rounds of review found assertions that could not fail, both fixed and then mutation-proved:

- The first browser assertions were vacuous. `getByRole("button", { name: "@" })` matches the *accessible name*, which the `aria-label` overrides, and `{ name: "Search octocat again" }` is a case-insensitive **substring** match that also matched `@OCTOCAT`. Replaced with `toHaveText(["Clear", "@octocat"])` on the region, which pins count, order, and spelling together. Removing the blank guard fails it; removing the case-dedup fails it.
- The cap was tested against blanks but not duplicates — the same defect. A mis-implementation counting duplicates toward the cap passed all 21 tests while silently returning four shortcuts instead of five. Now covered, and that case is the only one of 22 that catches it.

Related, found during review and filed rather than fixed here: #148 (a maximum-length handle may overflow the shortcut row at 320px — pre-existing, and the measurement wants confirming in a browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)