### PR TITLE
chore(deps): drop the unused clsx and tailwind-merge packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 - Partial commit results now offer a **Search again** button in place. A retry that succeeds replaces the partial result, one that comes back partial again says so, and one that fails leaves the commits on screen and explains why instead of replacing them with an error screen. Each outcome is announced to assistive technology.
 
+### Removed
+
+- Dropped the `clsx` and `tailwind-merge` dependencies, which nothing imported. Both are conventional in a Tailwind project and both arrived with the initial commit, but no revision since has ever imported either one: every component in this app composes `className` with a template literal, so neither package had a single call site in any version of this code. They shipped nothing, while each remained a package the audit gate had to keep clearing and Dependabot had to keep proposing upgrades for. Nothing else in the tree depended on them, so removing the two declarations removed them outright. No behaviour and no styling changed; a future need for conditional class composition can add one back deliberately.
+
 ### Fixed
 
 - A release tag now names a commit that was proven healthy in production, rather than one that merged and was followed by something healthy being observed. The production health check pointed a browser at a mutable alias without ever asking which commit was answering, so a deployment still in flight — or a failed one leaving the previous build live — produced a green run that said nothing about the code it was supposed to be checking. The run now asks `/api/health` what is deployed and stops in seconds if it is not the commit that triggered it. Promotion had a related gap from the other side: it decided whether a deployment had been overtaken by comparing against the tip of `main`, which advances at merge, while a deployment becomes live later and may never — so a newer commit that was still deploying, or that failed, suppressed the release of the commit genuinely in production and that release was never cut. It now resolves the live deployment directly and refuses to guess when none can be found.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,12 @@
       "version": "0.3.0",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
-        "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
         "next": "16.3.0",
         "octokit": "^5.0.5",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "react-icons": "^5.7.0",
-        "tailwind-merge": "^3.6.0"
+        "react-icons": "^5.7.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.62.1",
@@ -4120,15 +4118,6 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -8183,16 +8172,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tailwind-merge": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
-      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
-      }
     },
     "node_modules/tailwindcss": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -24,14 +24,12 @@
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
-    "clsx": "^2.1.1",
     "date-fns": "^4.4.0",
     "next": "16.3.0",
     "octokit": "^5.0.5",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "react-icons": "^5.7.0",
-    "tailwind-merge": "^3.6.0"
+    "react-icons": "^5.7.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",


### PR DESCRIPTION
## What

Removes `clsx` and `tailwind-merge` from `dependencies` and regenerates the lockfile. No source files change.

## Why

Neither package is imported anywhere in the repository. Both arrived with the initial commit (`bd4ef05`) and **no revision since has ever imported either one** — verified with `git log -S` across `app/` and the former `components/` directory. Every component in this app composes `className` with a template literal, so neither had a call site in any version of this code.

They shipped nothing, while each remained a package the `npm audit` gate had to keep clearing and Dependabot had to keep proposing upgrades for.

`npm ls clsx tailwind-merge` confirmed both were top-level only with no other dependents, so removing the two declarations removed them outright (`removed 2 packages`).

## Verification

`npm run validate` passes end to end on this branch:

- `npm audit` — 0 vulnerabilities
- `npm run test:coverage` — thresholds held
- `npm run test:e2e` — 51 passed, 1 skipped, across chromium / mobile-chrome / webkit
- `npm run lint`, `npm run format:check`, `npm run check:agent-docs`, `npm run check:labels`
- `npm run build` — production build clean

The build and the full unit suite are what make this safe: had anything imported either package, both would fail.

## Notes

No user-visible or behavioural change. A `CHANGELOG.md` entry is included under `### Removed`, since dropping a dependency is an operational change worth a release-notes line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)