### PR TITLE
perf(app): build the commit date formatters once

### DIFF
--- a/app/_home/FirstCommitDisplay.tsx
+++ b/app/_home/FirstCommitDisplay.tsx
@@ -9,22 +9,25 @@ type FirstCommitDisplayProps = {
   isMain?: boolean;
 };
 
-function formatCommitDate(date: Date) {
-  return new Intl.DateTimeFormat("en", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(date);
-}
+// Built once at module scope rather than on every call. `Intl.DateTimeFormat` is among the more
+// expensive constructors the platform offers -- it resolves a locale and builds a pattern each time
+// -- and a rendered result was constructing eleven of them: the hover title on each of the ten
+// commit cards, plus the summary date on the main one, repeated on every re-render a retry or a
+// share status caused. Both configurations are constant, and both are deliberately pinned to `en`
+// and UTC so a commit reads the same date wherever it is viewed, so there is nothing per-call to
+// close over and nothing a shared instance can leak between cards.
+const commitDateFormat = new Intl.DateTimeFormat("en", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  timeZone: "UTC",
+});
 
-function formatCommitDateTime(date: Date) {
-  return new Intl.DateTimeFormat("en", {
-    dateStyle: "medium",
-    timeStyle: "short",
-    timeZone: "UTC",
-  }).format(date);
-}
+const commitDateTimeFormat = new Intl.DateTimeFormat("en", {
+  dateStyle: "medium",
+  timeStyle: "short",
+  timeZone: "UTC",
+});
 
 export default function FirstCommitDisplay({ data, isMain = true }: FirstCommitDisplayProps) {
   const parsedDate = new Date(data.date);
@@ -111,7 +114,7 @@ export default function FirstCommitDisplay({ data, isMain = true }: FirstCommitD
               </a>
               <span>committed</span>
               {dateObj ? (
-                <time dateTime={data.date} title={formatCommitDateTime(dateObj)}>
+                <time dateTime={data.date} title={commitDateTimeFormat.format(dateObj)}>
                   {formatDistanceToNow(dateObj, { addSuffix: true })}
                 </time>
               ) : (
@@ -128,7 +131,7 @@ export default function FirstCommitDisplay({ data, isMain = true }: FirstCommitD
                   <dt className="font-semibold text-[var(--github-gray-dark)]">Commit date</dt>
                   <dd className="mt-1">
                     {dateObj ? (
-                      <time dateTime={data.date}>{formatCommitDate(dateObj)}</time>
+                      <time dateTime={data.date}>{commitDateFormat.format(dateObj)}</time>
                     ) : (
                       "Date unavailable"
                     )}

--- a/app/_lib/commitSearchRateLimit.test.ts
+++ b/app/_lib/commitSearchRateLimit.test.ts
@@ -11,6 +11,7 @@ import {
 
 const CLIENT = "client-key-a";
 const OTHER_CLIENT = "client-key-b";
+const THIRD_CLIENT = "client-key-c";
 
 /** Runs `count` searches for one client, `intervalMs` apart, and reports every outcome. */
 function searchAtInterval(clientKey: string, count: number, intervalMs: number, startedAt = 0) {
@@ -118,5 +119,32 @@ describe("allowCommitSearch", () => {
     allowCommitSearch(OTHER_CLIENT, COMMIT_SEARCH_RATE_LIMIT_WINDOW_MS + 1);
 
     expect(trackedCommitSearchClientKeys()).toEqual([OTHER_CLIENT]);
+  });
+
+  it("drops an idle client sitting behind an active one in eviction order", () => {
+    // Eviction order is *not* sorted by last-search time, so dropping idle clients has to look
+    // at every entry rather than stopping at the first one still inside the window. A refused
+    // search re-inserts its client at the tail without recording a new time -- deliberately, so
+    // that being evicted cannot become a reprieve -- which leaves that client behind a newer
+    // entry while its own last search is older.
+    //
+    // This arrangement is what makes an early exit wrong, and it is reachable: CLIENT spends its
+    // whole allowance, OTHER_CLIENT searches once a millisecond later, and CLIENT is then refused,
+    // which moves it behind OTHER_CLIENT while its own newest search stays the older of the two.
+    // Every time below is derived from the limit so the arrangement survives a change to it.
+    const startedAt = 1_000;
+    const clientLastSearchedAt = startedAt + COMMIT_SEARCH_RATE_LIMIT_MAX_SEARCHES - 1;
+
+    searchAtInterval(CLIENT, COMMIT_SEARCH_RATE_LIMIT_MAX_SEARCHES, 1, startedAt);
+    allowCommitSearch(OTHER_CLIENT, clientLastSearchedAt + 1);
+    expect(allowCommitSearch(CLIENT, clientLastSearchedAt + 2)).toBe(false);
+    expect(trackedCommitSearchClientKeys()).toEqual([OTHER_CLIENT, CLIENT]);
+
+    // The one instant where OTHER_CLIENT's search is still inside the window and CLIENT's is not,
+    // so the only idle client is the one standing *after* the active one. An eviction pass that
+    // stopped at the first client still inside the window would leave CLIENT behind.
+    allowCommitSearch(THIRD_CLIENT, clientLastSearchedAt + COMMIT_SEARCH_RATE_LIMIT_WINDOW_MS);
+
+    expect(trackedCommitSearchClientKeys()).toEqual([OTHER_CLIENT, THIRD_CLIENT]);
   });
 });


### PR DESCRIPTION
Two changes: one optimisation applied, and one **not** applied with a test explaining why.

## Applied: build the commit date formatters once

`FirstCommitDisplay` constructed a fresh `Intl.DateTimeFormat` on every call. A rendered result builds **eleven** of them — the hover title on each of the ten commit cards, plus the summary date on the main one — and again on every re-render a retry or a share status causes. `Intl.DateTimeFormat` is among the more expensive constructors the platform offers: it resolves a locale and builds a pattern each time.

Both configurations are constant and deliberately pinned to `en` and UTC, so there is nothing per-call to close over. `Intl.DateTimeFormat.prototype.format` holds no per-call state, so a shared instance cannot leak anything between cards.

Output is unchanged and already pinned: `FirstCommitDisplay.test.tsx` asserts the exact string `"Jan 1, 2024"`, and the malformed-date fallback test still passes.

## Not applied: an early exit in `dropIdleClients`

The plan for this PR included short-circuiting the rate limiter's idle-client sweep, which scans up to 500 entries on every allowed search. The reasoning was that `allowCommitSearch` deletes and re-inserts on each call, so insertion order should be ascending by last-search time — letting the sweep `break` at the first client still inside the window.

**That reasoning is wrong.** When a client is *refused*, it is deleted and re-inserted at the tail, but nothing is pushed to its `searchTimes`, so its last-search time does not advance. The existing comment says this is deliberate — being evicted is a reprieve, so a client being refused should not get one. The consequence is that insertion order is **not** sorted by last-search time, and an idle client can sit *behind* an active one.

This is reachable, not theoretical. The new test builds the arrangement: `CLIENT` spends its whole allowance, `OTHER_CLIENT` searches one millisecond later, then `CLIENT` is refused — which moves it behind `OTHER_CLIENT` while its own newest search stays older. At one instant, `OTHER_CLIENT` is inside the window and `CLIENT` is not, so the only idle client stands after the active one.

Verified the test has teeth by temporarily applying the `break`:

```
AssertionError: expected [ Array(3) ] to deeply equal [ 'client-key-b', 'client-key-c' ]
```

The idle client survives eviction — which fails *open*, silently refilling an allowance rather than erroring, so nothing else would have caught it. `commitSearchRateLimit.ts` is therefore **unchanged**; only the test is added, so the next person to spot this scan is warned off it.

The scan is also not worth optimising: it is bounded at 500 cheap array-index reads on a path that otherwise makes an HTTP request to GitHub with a 10-second timeout.

## Verification

`npm run validate` passes end to end:

- 492 unit tests (491 + the new one)
- Coverage 96.61 stmts / 93.35 branch / 98.9 funcs / 97.82 lines, all above their floors
- Playwright 51 passed across chromium / mobile-chrome / webkit
- `npm audit`, lint, format, `check:agent-docs`, `check:labels`, production build all clean

## No CHANGELOG entry

Purely internal, per the step 9 exemption: no user-visible or operational effect. The rendered dates are identical, and the rate limiter's behaviour is unchanged by construction — its source is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
