### PR TITLE
docs(agents): describe the import convention the code follows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,11 +73,20 @@ land in it. Name new internal folders the same way; a route directory keeps its 
 
 **A component lives beside the feature that uses it.** Everything the homepage renders is in
 `app/_home/`; a component used by more than one feature, or by the root layout rather than a
-feature, goes in `app/_components/`. There is no root-level `components/`. The rule decides the
-import style too: relative within a feature, aliased with `@/` only across a boundary — so a
-relative import now means "same feature" rather than nothing in particular. Before adding a
+feature, goes in `app/_components/`. There is no root-level `components/`. Before adding a
 component to `app/_components/`, check that it really has more than one caller; the last occupant
 of the root `components/` directory had exactly one, three directories away.
+
+**Depth decides the import style, not the boundary crossed.** A route file under `app/api/` reaches
+a shared module through the `@/` alias — `@/app/_lib/logger` — because it sits three levels down
+and the relative form, `../../_lib/logger`, counts directories rather than naming anything, and
+silently means a different module if the route ever moves. Everything else under `app/` sits at
+most one directory from `_lib` and imports it relatively: `../_lib/analytics` from a feature
+folder, `./_lib/username` from `app/page.tsx`. That is what the code does in all 32 places a file outside `app/_lib/` imports
+from it, and the split is worth keeping because each half is the form that stays readable at that
+depth. An earlier version of this rule said "relative within a feature, aliased with `@/` only
+across a boundary", which described neither half: all 29 relative imports cross out of their own
+folder, and the 3 aliased ones are exactly the route files.
 
 **The same test decides where a module goes.** A module read by something other than the feature it
 sits in belongs in `app/_lib/`, and an import reaching into a feature folder from outside that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Changed
 
+- The agent instructions now describe the import convention the code actually follows. They said imports were "relative within a feature, aliased with `@/` only across a boundary", which matched neither half of the codebase: all 29 relative imports of a shared module cross out of their own folder, and the 3 aliased ones are exactly the route files under `app/api/`. What decides the form is depth, not the boundary crossed — a route file sits three levels down, where the relative path counts directories instead of naming anything and quietly means a different module if the route moves. The rule now says that, so it can be checked against the code rather than read as a principle nothing obeys.
+
 - Analytics moved out of the homepage feature folder. `analytics.ts` sat in `app/_home/`, the directory for things only the homepage uses, while the root layout's analytics component imported it from outside — so every page load pulled a module out of the homepage feature to do something with no connection to searching for a commit. It now sits in `app/_lib/` with the other shared modules, which leaves `app/_home/` meaning what its name claims. The agent instructions gained the rule that decides this for the next module, and their layout list picked up the two files it had fallen behind on. Documentation and file locations only; no behaviour changed and the analytics events themselves are untouched.
 
 ### Removed


### PR DESCRIPTION
Resolves the one item left open by #192. Documentation only — no code changes, and the convention itself is unchanged.

## The rule described neither half of the codebase

AGENTS.md said imports were "relative within a feature, aliased with `@/` only across a boundary". Measured against the code:

| Form | Count | Where |
| --- | --- | --- |
| `@/app/_lib/*` | 3 | exactly the route files under `app/api/` |
| `../_lib/*`, `./_lib/*` | 29 | everything else under `app/` |

All 29 relative imports cross out of their own folder, so "relative within a feature" was not what was happening; and the 3 aliased ones are not a boundary category, they are a location.

## What actually decides it is depth

A route file sits three levels down. Its relative path to a shared module is `../../_lib/logger`, which counts directories rather than naming anything and silently resolves to a different place if the route ever moves — so route files use `@/app/_lib/logger`. Everything else is at most one directory from `_lib`, where the relative form is the readable one.

The rule now says that, which makes it checkable against the code rather than a principle nothing obeys. The old sentence is quoted in the new paragraph so the correction is legible to someone who remembers the previous wording.

## Verification

`PASS (unread-paths)` — every modified path (`AGENTS.md`, `CHANGELOG.md`) is a `*.md` file, which is exactly the exempt set in step 7 of AGENTS.md. Ran `npm run check:agent-docs`, which reports the docs consistent and is the one gate command that reads these paths; here it verifies the change rather than merely re-checking repository state, since the change edits AGENTS.md.

Skipped `npm audit`, `test:coverage`, `test:e2e`, `lint`, `format:check`, `check:labels`, and `build`: `.prettierignore` excludes `*.md` wholesale, ESLint does not lint Markdown, Vitest collects only from `app/` and `scripts/`, and the remaining three read source, `package.json`, and `.github/labels.yml`. CI runs the complete gate on this PR regardless.

## Note on the counts

An earlier version of this PR said 27 total / 24 relative. Those were correct when measured during #192 but stale by the time they were written down — the analytics move in that PR added five relative imports. Recounted before committing: 32 total, 29 relative, 3 aliased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
