### PR TITLE
chore(tooling): extend Entire stop-hook timeout

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -31,7 +31,7 @@
           {
             "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex stop'",
-            "timeout": 30
+            "timeout": 300
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Changed
 
+- The Entire CLI Codex stop hook now has up to 300 seconds to finish writing its checkpoint before
+  Codex terminates it, increased from 30 seconds for larger sessions that need longer to finalize.
+  Other Entire hooks retain their existing 30-second limits.
+
 - The repository front door now leads with the live product, current build and release status, an
   accurate screenshot, a concise local quick start, and a compact guide to the rest of the
   documentation. Detailed capabilities, privacy boundaries, and GitHub search limitations moved to


### PR DESCRIPTION
## Summary

- increase the Entire CLI Codex `Stop` hook timeout from 30 to 300 seconds
- keep the other Entire Codex hook timeouts at 30 seconds
- document the operational change in the changelog

## Why

Larger sessions can need more than 30 seconds for Entire to finish writing their final checkpoint. The stop hook now has up to five minutes to finalize without expanding the runtime allowance for routine hooks.

## Validation

- focused JSON assertion parsed `.codex/hooks.json`, proved `Stop` is `300`, and proved `PostToolUse`, `SessionStart`, and `UserPromptSubmit` remain `30`
- `git diff --check`
- `npm run check:agent-docs`
- verifier: `PASS (unread-paths)`; the remaining local gate commands do not read `.codex/` or Markdown and were skipped under the repository's documented exemption
- UI review: no user-visible surface
- code review: approved with 0 findings

## Impact

Codex sessions using Entire may wait up to five minutes for the final checkpoint hook. Application behavior is unchanged.
