### PR TITLE
chore(tooling): extend all Entire hook timeouts

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex post-tool-use'",
-            "timeout": 30
+            "timeout": 300
           }
         ]
       }
@@ -19,7 +19,7 @@
           {
             "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then printf \"%s\\n\" \"{\\\"systemMessage\\\":\\\"Entire CLI is enabled but not installed or not on PATH. Installation guide: https://docs.entire.io/cli/installation#installation-methods\\\"}\"; exit 0; fi; exec entire hooks codex session-start'",
-            "timeout": 30
+            "timeout": 300
           }
         ]
       }
@@ -43,7 +43,7 @@
           {
             "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex user-prompt-submit'",
-            "timeout": 30
+            "timeout": 300
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ This project follows a lightweight, human-curated changelog. Keep the newest cha
 
 ### Changed
 
-- The Entire CLI Codex stop hook now has up to 300 seconds to finish writing its checkpoint before
-  Codex terminates it, increased from 30 seconds for larger sessions that need longer to finalize.
-  Other Entire hooks retain their existing 30-second limits.
+- Every Entire CLI Codex hook now has up to 300 seconds to finish before Codex terminates it,
+  increased from 30 seconds for larger sessions and checkpoint operations that need longer to
+  finalize.
 
 - The repository front door now leads with the live product, current build and release status, an
   accurate screenshot, a concise local quick start, and a compact guide to the rest of the


### PR DESCRIPTION
## Summary

- raise `PostToolUse`, `SessionStart`, and `UserPromptSubmit` Entire Codex hook timeouts from 30 to 300 seconds
- keep the already-extended `Stop` hook at 300 seconds
- reconcile the Unreleased changelog entry with the final consistent configuration

## Why

Entire operations can take longer for larger sessions and checkpoints. Giving every Codex hook the same five-minute ceiling avoids inconsistent timeout behavior across session startup, prompt submission, tool checkpoints, and shutdown.

## Validation

- focused JSON assertion confirmed exactly four hook groups exist and each contains one command with timeout `300`
- `git diff --check`
- `npm run check:agent-docs`
- verifier: `PASS (unread-paths)`; the remaining local gates do not read `.codex/` or Markdown
- UI review: no user-visible surface
- code review: approved with 0 findings

## Impact

All Entire Codex hooks may now run for up to five minutes before Codex terminates them. Application behavior is unchanged.
